### PR TITLE
feat: 문서 발행 시 비밀번호 등록 기능 추가

### DIFF
--- a/app/document/[id]/DocumentDetailClient.tsx
+++ b/app/document/[id]/DocumentDetailClient.tsx
@@ -5,7 +5,9 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { ArrowLeft, Edit, Share, ExternalLink, Copy } from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { ArrowLeft, Edit, Share, ExternalLink, Copy, Key } from "lucide-react"
 import Link from "next/link"
 import AreaSelector from "@/components/area-selector"
 import { publishDocument, updateSignatureAreas } from "@/app/actions/document-actions"
@@ -31,6 +33,8 @@ export default function DocumentDetailClient({ documentData, signatures }: Docum
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [publishedUrl, setPublishedUrl] = useState<string | null>(null)
+  const [password, setPassword] = useState<string>('')
+  const [showPasswordInput, setShowPasswordInput] = useState<boolean>(false)
   const documentContainerRef = useRef<HTMLDivElement>(null)
   const [scrollPosition, setScrollPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
 
@@ -112,7 +116,7 @@ export default function DocumentDetailClient({ documentData, signatures }: Docum
     setError(null)
 
     try {
-      const result = await publishDocument(document.id)
+      const result = await publishDocument(document.id, password || null)
 
       if (result.error) {
         setError(result.error)
@@ -124,6 +128,10 @@ export default function DocumentDetailClient({ documentData, signatures }: Docum
       if (result.shortUrl) {
         setPublishedUrl(`${window.location.origin}/sign/${result.shortUrl}`)
       }
+
+      // Reset password input
+      setPassword('')
+      setShowPasswordInput(false)
 
       // Refresh the page data
       router.refresh()
@@ -181,13 +189,23 @@ export default function DocumentDetailClient({ documentData, signatures }: Docum
             )}
 
             {canPublish && !isEditMode && (
-              <Button
-                onClick={handlePublish}
-                disabled={isLoading}
-              >
-                <Share className="mr-2 h-4 w-4" />
-                {isLoading ? '발행 중...' : '발행하기'}
-              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  onClick={() => setShowPasswordInput(!showPasswordInput)}
+                  disabled={isLoading}
+                >
+                  <Key className="mr-2 h-4 w-4" />
+                  {showPasswordInput ? '비밀번호 설정 취소' : '비밀번호 설정'}
+                </Button>
+                <Button
+                  onClick={handlePublish}
+                  disabled={isLoading}
+                >
+                  <Share className="mr-2 h-4 w-4" />
+                  {isLoading ? '발행 중...' : '발행하기'}
+                </Button>
+              </div>
             )}
 
             {isEditMode && (
@@ -199,6 +217,32 @@ export default function DocumentDetailClient({ documentData, signatures }: Docum
               </Button>
             )}
           </div>
+
+          {/* Password Input */}
+          {showPasswordInput && canPublish && (
+            <Card className="mb-6">
+              <CardHeader>
+                <CardTitle className="text-lg">문서 보안 설정</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="password">비밀번호 (선택사항)</Label>
+                    <Input
+                      id="password"
+                      type="password"
+                      placeholder="서명 페이지 접근 시 필요한 비밀번호를 입력하세요"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                    />
+                  </div>
+                  <p className="text-sm text-gray-600">
+                    비밀번호를 설정하면 서명자가 문서에 접근할 때 비밀번호를 입력해야 합니다. 비워두면 누구나 접근할 수 있습니다.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          )}
 
           {/* Published URL Display */}
           {isPublished && document.short_url && (

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -18,6 +18,7 @@ export interface Database {
           signed_file_url: string | null
           created_at: string
           status: 'draft' | 'published' | 'completed'
+          password: string | null
         }
         Insert: {
           id?: string
@@ -27,6 +28,7 @@ export interface Database {
           signed_file_url?: string | null
           created_at?: string
           status?: 'draft' | 'published' | 'completed'
+          password?: string | null
         }
         Update: {
           id?: string
@@ -36,6 +38,7 @@ export interface Database {
           signed_file_url?: string | null
           created_at?: string
           status?: 'draft' | 'published' | 'completed'
+          password?: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 문서를 공개할 때 비밀번호를 설정할 수 있습니다.
  - 서명 페이지에서 비밀번호 검증 화면이 제공되며, 올바른 비밀번호 입력 시 문서에 접근할 수 있습니다.

- UX/UI
  - 공개 플로우에 비밀번호 설정 토글과 입력 필드가 추가되었습니다.
  - 안내 문구와 아이콘이 업데이트되었고, 검증 중 로딩 표시가 제공됩니다.
  - 비밀번호 미입력, 불일치, 예기치 못한 오류 등에 대한 사용자 친화적 오류 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->