### PR TITLE
✨ feat: improve document cards and action layout, truncate names

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -218,44 +218,54 @@ export default function DocumentDetailComponent({
           </div>
 
           {/* Action Buttons */}
-          <div className="flex gap-4 mb-6">
-            {canEdit && (
-              <Button
-                variant="outline"
-                onClick={handleEditModeToggle}
-                disabled={isLoading}
-              >
-                <Edit className="mr-2 h-4 w-4" />
-                {isEditMode ? "편집 취소" : "수정하기"}
-              </Button>
-            )}
+          <div className="flex items-center justify-between mb-6">
+            <div className="flex gap-4">
+              {canEdit && (
+                <Button
+                  variant="outline"
+                  onClick={handleEditModeToggle}
+                  disabled={isLoading}
+                >
+                  <Edit className="mr-2 h-4 w-4" />
+                  {isEditMode ? "편집 취소" : "수정하기"}
+                </Button>
+              )}
 
-            {canPublish && !isEditMode && (
-              <Button
-                onClick={() => setIsPublishModalOpen(true)}
-                disabled={isLoading}
-              >
-                <Share className="mr-2 h-4 w-4" />
-                발급하기
-              </Button>
-            )}
+              {isEditMode && (
+                <Button onClick={handleAddSignatureArea} disabled={isLoading}>
+                  서명 영역 추가
+                </Button>
+              )}
 
-            {isEditMode && (
-              <Button onClick={handleSaveChanges} disabled={isLoading}>
-                {isLoading ? "저장 중..." : "변경사항 저장"}
-              </Button>
-            )}
+              {isCompleted && signedDocumentUrl && (
+                <Button
+                  variant="outline"
+                  onClick={handleDownloadSignedDocument}
+                  disabled={isLoading}
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  서명완료 문서 다운로드
+                </Button>
+              )}
+            </div>
 
-            {isCompleted && signedDocumentUrl && (
-              <Button
-                variant="outline"
-                onClick={handleDownloadSignedDocument}
-                disabled={isLoading}
-              >
-                <Download className="mr-2 h-4 w-4" />
-                서명완료 문서 다운로드
-              </Button>
-            )}
+            <div className="flex gap-4">
+              {isEditMode && (
+                <Button onClick={handleSaveChanges} disabled={isLoading}>
+                  {isLoading ? "저장 중..." : "변경사항 저장"}
+                </Button>
+              )}
+
+              {canPublish && !isEditMode && (
+                <Button
+                  onClick={() => setIsPublishModalOpen(true)}
+                  disabled={isLoading}
+                >
+                  <Share className="mr-2 h-4 w-4" />
+                  발급하기
+                </Button>
+              )}
+            </div>
           </div>
 
           {/* Published URL Display */}
@@ -347,14 +357,6 @@ export default function DocumentDetailComponent({
           )}
         </div>
 
-        {/* Edit Mode Controls */}
-        {isEditMode && !isSelecting && (
-          <div className="mt-6 flex gap-4">
-            <Button onClick={handleAddSignatureArea} disabled={isLoading}>
-              서명 영역 추가
-            </Button>
-          </div>
-        )}
 
         {/* Publish Document Modal */}
         <PublishDocumentModal

--- a/components/dashboard/document-card.tsx
+++ b/components/dashboard/document-card.tsx
@@ -41,24 +41,33 @@ export function DocumentCard({ document }: DocumentCardProps) {
     }
   );
 
+  // Truncate filename if it's too long
+  const truncateFilename = (filename: string, maxLength: number = 45) => {
+    if (filename.length <= maxLength) return filename;
+    return filename.slice(0, maxLength) + "...";
+  };
+
   return (
     <Link href={`/document/${document.id}`} className="block group">
-      <Card className="transition-all duration-200 hover:shadow-md hover:border-primary/20 group-hover:scale-[1.02]">
-        <CardHeader className="pb-3">
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex items-center gap-2 min-w-0 flex-1">
-              <FileText className="h-4 w-4 text-primary flex-shrink-0" />
-              <h3 className="font-medium text-sm leading-relaxed line-clamp-2 break-all">
-                {document.filename}
-              </h3>
-            </div>
+      <Card className="transition-all duration-200 hover:shadow-md hover:border-primary/20 group-hover:scale-[1.02] h-48 flex flex-col">
+        <CardHeader className="pb-3 flex-1 flex flex-col justify-between">
+          <div className="flex items-start justify-between gap-2 mb-2">
             <Badge variant={statusBadge.variant} className="flex-shrink-0 text-xs">
               {statusBadge.label}
             </Badge>
           </div>
+          <div className="flex flex-col items-center text-center space-y-3">
+            <FileText className="h-8 w-8 text-primary flex-shrink-0" />
+            <h3
+              className="font-medium text-sm leading-relaxed text-center px-2 break-words"
+              title={document.filename}
+            >
+              {truncateFilename(document.filename)}
+            </h3>
+          </div>
         </CardHeader>
-        <CardContent className="pt-0">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <CardContent className="pt-0 pb-4 mt-auto">
+          <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
             <Calendar className="h-3 w-3" />
             <time dateTime={document.created_at}>{formattedDate}</time>
           </div>

--- a/components/dashboard/infinite-scroll-documents.tsx
+++ b/components/dashboard/infinite-scroll-documents.tsx
@@ -111,14 +111,6 @@ export function InfiniteScrollDocuments({
         </div>
       )}
 
-      {/* End of List */}
-      {!hasMore && documents.length > 0 && (
-        <div className="text-center py-8">
-          <p className="text-sm text-muted-foreground">
-            {t("dashboard.end.message")}
-          </p>
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
- Refactor document-card to a vertical card with fixed height, center file icon and title, increase FileText icon size, move status badge to top, center filename with title attribute.
- Add truncateFilename helper to show ellipsis for filenames over 45 characters.
- Adjust CardContent to center creation date metadata and pin it to the bottom (mt-auto/pb) for consistent spacing.
- Update DocumentDetailPage action bar to a two-column layout: left with edit/publish/add-signature/download actions, right with save and grouped buttons; conditionally show Download (isCompleted & signedDocumentUrl) and Add Signature Area (isEditMode).
- Remove redundant "End of List" message from infinite-scroll-documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 편집 모드에서 “서명 영역 추가” 버튼을 도입해 서명 영역을 빠르게 추가할 수 있습니다.
  - 문서 카드의 긴 파일명을 말줄임으로 표시하고, 호버 시 전체 파일명을 툴팁으로 확인할 수 있습니다.
- Style
  - 문서 상세 상단 액션 버튼을 2열(좌: 편집, 우: 발행/저장/다운로드)로 재구성하고 하단 편집 컨트롤을 통합했습니다.
  - 문서 카드 레이아웃을 중앙 정렬 아이콘·파일명과 하단 날짜 영역으로 재배치했습니다.
  - 무한 스크롤의 목록 끝 안내 문구를 제거해 종료 상태를 간결화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->