### PR TITLE
✨ feat: centralize sign-out and redirect to login

### DIFF
--- a/app/actions/auth-actions.ts
+++ b/app/actions/auth-actions.ts
@@ -18,6 +18,6 @@ export async function signOut() {
     throw new Error("로그아웃 중 오류가 발생했습니다.");
   }
 
-  // 로그아웃 후 메인 페이지로 리다이렉트
-  redirect("/");
+  // 로그아웃 후 로그인 페이지로 리다이렉트
+  redirect("/login");
 }

--- a/components/user-avatar.tsx
+++ b/components/user-avatar.tsx
@@ -11,11 +11,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/contexts/language-context";
-import { createClientSupabase } from "@/lib/supabase/client";
 import { User } from "@supabase/supabase-js";
 import { LogOut, User as UserIcon, LayoutDashboard } from "lucide-react";
 import { useState } from "react";
 import Link from "next/link";
+import { signOut } from "@/app/actions/auth-actions";
 
 interface UserAvatarProps {
   user: User;
@@ -24,13 +24,11 @@ interface UserAvatarProps {
 export default function UserAvatar({ user }: UserAvatarProps) {
   const { t } = useLanguage();
   const [isSigningOut, setIsSigningOut] = useState(false);
-  const supabase = createClientSupabase();
 
   const handleSignOut = async () => {
     try {
       setIsSigningOut(true);
-      await supabase.auth.signOut();
-      // onAuthStateChange가 자동으로 헤더를 갱신함
+      await signOut();
     } catch (error) {
       console.error("Sign out error:", error);
       setIsSigningOut(false);


### PR DESCRIPTION
- Move sign logic to a shared auth action to central session termination.
- Update UserAvatar to call the new signOut action instead of creating a Supabase client directly.
- Change post-logout redirect to send users to the login page (authentication entry) instead of the main page.
- Adjust state handling for async sign-out and retain error logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 로그아웃 성공 시 이동 경로를 홈("/")에서 로그인("/login") 페이지로 변경해 사용자가 즉시 재로그인할 수 있도록 개선했습니다.

- **Refactor**
  - 컴포넌트에서 직접 클라이언트를 생성하던 방식 대신, 중앙화된 signOut 액션을 사용하도록 통합했습니다.
  - 관련 임포트를 정리하고, 기존 UI 상태 관리(진행 중 비활성화)와 오류 처리 흐름은 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->