### PR TITLE
✨ feat(auth): reset password page and clean register metadataIntroduce a full client-side ResetPasswordPage component with form

### DIFF
--- a/app/(auth)/forgot-password/ForgotPasswordPage.tsx
+++ b/app/(auth)/forgot-password/ForgotPasswordPage.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import type React from "react";
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { ArrowLeft, Mail, SendHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useLanguage } from "@/contexts/language-context";
+import { forgotPassword } from "./actions";
+import { useFormState } from "react-dom";
+import { SubmitButton } from "@/components/ui/submit-button";
+
+export default function ForgotPasswordPage() {
+  const { t } = useLanguage();
+  const [state, dispatch] = useFormState(forgotPassword, null);
+  const [emailSent, setEmailSent] = useState(false);
+
+  // Check if email was sent successfully
+  useEffect(() => {
+    if (state?.success) {
+      setEmailSent(true);
+    }
+  }, [state?.success]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-primary/5 to-primary/10">
+      <div className="w-full max-w-md space-y-8">
+        <div className="bg-background rounded-lg shadow-lg p-8 border">
+          {/* Header */}
+          <div className="text-center space-y-2 mb-8">
+            <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+              <Mail className="h-8 w-8 text-primary" />
+            </div>
+            <h1 className="text-2xl font-bold">
+              {emailSent ? t("forgotPassword.checkEmail") : t("forgotPassword.title")}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {emailSent
+                ? t("forgotPassword.emailSentMessage")
+                : t("forgotPassword.subtitle")
+              }
+            </p>
+          </div>
+
+          {emailSent ? (
+            /* Email sent success state */
+            <div className="space-y-6">
+              <Alert>
+                <SendHorizontal className="h-4 w-4" />
+                <AlertDescription>
+                  {t("forgotPassword.checkInbox")}
+                </AlertDescription>
+              </Alert>
+
+              <div className="text-center space-y-4">
+                <p className="text-sm text-muted-foreground">
+                  {t("forgotPassword.didntReceive")}
+                </p>
+                <Button
+                  variant="outline"
+                  onClick={() => setEmailSent(false)}
+                  className="w-full"
+                >
+                  {t("forgotPassword.sendAnother")}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            /* Email input form */
+            <form action={dispatch} className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="email">{t("forgotPassword.emailLabel")}</Label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    id="email"
+                    type="email"
+                    name="email"
+                    placeholder="name@example.com"
+                    className="pl-10"
+                    required
+                  />
+                </div>
+                {state?.fieldErrors?.email && (
+                  <p className="text-sm text-destructive">
+                    {state.fieldErrors.email[0]}
+                  </p>
+                )}
+              </div>
+
+              {state?.error && (
+                <Alert variant="destructive">
+                  <AlertDescription>{state.error}</AlertDescription>
+                </Alert>
+              )}
+
+              <SubmitButton
+                label={t("forgotPassword.sendReset")}
+                pendingLabel={t("forgotPassword.sending")}
+                className="w-full"
+              />
+            </form>
+          )}
+
+          {/* Back to login */}
+          <div className="mt-8 text-center">
+            <Link
+              href="/login"
+              className="inline-flex items-center text-sm text-primary hover:underline"
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t("forgotPassword.backToLogin")}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/forgot-password/actions.ts
+++ b/app/(auth)/forgot-password/actions.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { createServerSupabase } from "@/lib/supabase/server";
+import { z } from "zod";
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email("Invalid email address"),
+});
+
+export async function forgotPassword(prevState: any, formData: FormData) {
+  const supabase = await createServerSupabase();
+
+  try {
+    // Validate form data
+    const validatedFields = forgotPasswordSchema.safeParse({
+      email: formData.get("email"),
+    });
+
+    if (!validatedFields.success) {
+      return {
+        error: null,
+        fieldErrors: validatedFields.error.flatten().fieldErrors,
+      };
+    }
+
+    const { email } = validatedFields.data;
+
+    // Send password reset email
+    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3001'}/auth/confirm?next=${encodeURIComponent('/reset-password')}`,
+    });
+
+    if (error) {
+      console.error("Password reset error:", error);
+      return {
+        error: "Failed to send password reset email. Please try again.",
+        fieldErrors: null,
+      };
+    }
+
+    return {
+      success: true,
+      error: null,
+      fieldErrors: null,
+    };
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return {
+      error: "An unexpected error occurred. Please try again.",
+      fieldErrors: null,
+    };
+  }
+}

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,5 @@
+import ForgotPasswordPage from "./ForgotPasswordPage";
+
+export default function Page() {
+  return <ForgotPasswordPage />;
+}

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next";
 import LoginPage from "./LoginPage";
 
-export const metadata: Metadata = {
-  title: "SeukSeuk - Login",
-  description: "Log in to your SeukSeuk account",
-};
-
 export default function Login() {
   return <LoginPage />;
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next";
 import RegisterPage from "./RegisterPage";
 
-export const metadata: Metadata = {
-  title: "SeukSeuk - Register",
-  description: "Create a new SeukSeuk account",
-};
-
 export default function Register() {
   return <RegisterPage />;
 }

--- a/app/(auth)/reset-password/ResetPasswordPage.tsx
+++ b/app/(auth)/reset-password/ResetPasswordPage.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import type React from "react";
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, KeyRound, Eye, EyeOff, CheckCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { useLanguage } from "@/contexts/language-context";
+import { resetPassword } from "./actions";
+import { useFormState } from "react-dom";
+import { SubmitButton } from "@/components/ui/submit-button";
+
+export default function ResetPasswordPage() {
+  const { t } = useLanguage();
+  const router = useRouter();
+  const [state, dispatch] = useFormState(resetPassword, null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  useEffect(() => {
+    if (state?.success) {
+      setIsSuccess(true);
+      // Redirect to login after 3 seconds
+      setTimeout(() => {
+        router.push('/login');
+      }, 3000);
+    }
+  }, [state?.success, router]);
+
+  if (isSuccess) {
+    return (
+      <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-primary/5 to-primary/10">
+        <div className="w-full max-w-md">
+          <div className="bg-background rounded-lg shadow-lg p-8 border text-center space-y-6">
+            <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+              <CheckCircle className="h-8 w-8 text-green-600" />
+            </div>
+            <div className="space-y-3">
+              <h1 className="text-xl font-semibold text-green-600">
+                {t("resetPassword.successTitle")}
+              </h1>
+              <p className="text-sm text-muted-foreground">
+                {t("resetPassword.successMessage")}
+              </p>
+            </div>
+            <Link href="/login">
+              <Button className="w-full">
+                {t("resetPassword.backToLogin")}
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-primary/5 to-primary/10">
+      <div className="w-full max-w-md space-y-8">
+        <div className="bg-background rounded-lg shadow-lg p-8 border">
+          {/* Header */}
+          <div className="text-center space-y-2 mb-8">
+            <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
+              <KeyRound className="h-8 w-8 text-primary" />
+            </div>
+            <h1 className="text-2xl font-bold">
+              {t("resetPassword.title")}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {t("resetPassword.subtitle")}
+            </p>
+          </div>
+
+          {/* Password Reset Form */}
+          <form action={dispatch} className="space-y-6">
+            <div className="space-y-4">
+              {/* New Password */}
+              <div className="space-y-2">
+                <Label htmlFor="password">{t("resetPassword.newPassword")}</Label>
+                <div className="relative">
+                  <KeyRound className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    name="password"
+                    placeholder="••••••••"
+                    className="pl-10 pr-10"
+                    minLength={6}
+                    required
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                    onClick={() => setShowPassword(!showPassword)}
+                  >
+                    {showPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+                {state?.fieldErrors?.password && (
+                  <p className="text-sm text-destructive">
+                    {state.fieldErrors.password[0]}
+                  </p>
+                )}
+              </div>
+
+              {/* Confirm Password */}
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">{t("resetPassword.confirmPassword")}</Label>
+                <div className="relative">
+                  <KeyRound className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                  <Input
+                    id="confirmPassword"
+                    type={showConfirmPassword ? "text" : "password"}
+                    name="confirmPassword"
+                    placeholder="••••••••"
+                    className="pl-10 pr-10"
+                    minLength={6}
+                    required
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                    onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  >
+                    {showConfirmPassword ? (
+                      <EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Eye className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+                {state?.fieldErrors?.confirmPassword && (
+                  <p className="text-sm text-destructive">
+                    {state.fieldErrors.confirmPassword[0]}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {state?.error && (
+              <Alert variant="destructive">
+                <AlertDescription>{state.error}</AlertDescription>
+              </Alert>
+            )}
+
+            <SubmitButton
+              label={t("resetPassword.updatePassword")}
+              pendingLabel={t("resetPassword.updating")}
+              className="w-full"
+            />
+          </form>
+
+          {/* Back to login */}
+          <div className="mt-8 text-center">
+            <Link
+              href="/login"
+              className="inline-flex items-center text-sm text-primary hover:underline"
+            >
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              {t("resetPassword.backToLogin")}
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(auth)/reset-password/actions.ts
+++ b/app/(auth)/reset-password/actions.ts
@@ -1,0 +1,61 @@
+"use server";
+
+import { createServerSupabase } from "@/lib/supabase/server";
+import { z } from "zod";
+
+const resetPasswordSchema = z.object({
+  password: z.string().min(6, "Password must be at least 6 characters"),
+  confirmPassword: z.string().min(6, "Password must be at least 6 characters"),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: "Passwords don't match",
+  path: ["confirmPassword"],
+});
+
+export async function resetPassword(prevState: any, formData: FormData) {
+  const supabase = await createServerSupabase();
+
+  try {
+    // Validate form data
+    const validatedFields = resetPasswordSchema.safeParse({
+      password: formData.get("password"),
+      confirmPassword: formData.get("confirmPassword"),
+    });
+
+    if (!validatedFields.success) {
+      return {
+        error: null,
+        fieldErrors: validatedFields.error.flatten().fieldErrors,
+      };
+    }
+
+    const { password } = validatedFields.data;
+
+    // Update the user's password
+    const { error: updateError } = await supabase.auth.updateUser({
+      password: password,
+    });
+
+    if (updateError) {
+      console.error("Password update error:", updateError);
+      return {
+        error: "Failed to update password. Please try again.",
+        fieldErrors: null,
+      };
+    }
+
+    // Sign out the user after password reset
+    await supabase.auth.signOut();
+
+    return {
+      success: true,
+      error: null,
+      fieldErrors: null,
+    };
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return {
+      error: "An unexpected error occurred. Please try again.",
+      fieldErrors: null,
+    };
+  }
+}

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,5 @@
+import ResetPasswordPage from "./ResetPasswordPage";
+
+export default function Page() {
+  return <ResetPasswordPage />;
+}

--- a/app/(billing)/pricing/components/PricingPage.tsx
+++ b/app/(billing)/pricing/components/PricingPage.tsx
@@ -68,13 +68,8 @@ export function PricingPage() {
           return;
         }
 
-        // 플랜 순서 정렬: Free → Pro → Enterprise
-        const sortedPlans = plansResult.plans.sort((a, b) => {
-          const order = { free: 0, pro: 1, enterprise: 2 };
-          const aOrder = order[a.name.toLowerCase()] ?? 999;
-          const bOrder = order[b.name.toLowerCase()] ?? 999;
-          return aOrder - bOrder;
-        });
+        // 플랜 순서 정렬: order 컬럼 사용
+        const sortedPlans = plansResult.plans.sort((a, b) => a.order - b.order);
 
         setPlans(sortedPlans);
         setCurrentSubscription(subscriptionResult.subscription);

--- a/app/(document)/upload/page.tsx
+++ b/app/(document)/upload/page.tsx
@@ -1,10 +1,4 @@
-import type { Metadata } from "next";
 import UploadPageComponent from "./components/UploadPage";
-
-export const metadata: Metadata = {
-  title: "SeukSeuk - Upload",
-  description: "Upload and manage your documents",
-};
 
 export default function UploadPage() {
   return <UploadPageComponent />;

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -1,11 +1,6 @@
 import type { Metadata } from "next";
 import HomePageComponent from "./components/HomePage";
 
-export const metadata: Metadata = {
-  title: "SeukSeuk - Online Document Signing",
-  description: "Upload, sign, and share documents online with ease",
-};
-
 export default function HomePage() {
   return <HomePageComponent />;
 }

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,0 +1,60 @@
+import { type EmailOtpType } from '@supabase/supabase-js'
+import { type NextRequest } from 'next/server'
+import { createServerSupabase } from '@/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const token_hash = searchParams.get('token_hash')
+  const token = searchParams.get('token')
+  const code = searchParams.get('code')
+  const type = searchParams.get('type') as EmailOtpType | null
+  const next = searchParams.get('next') ?? '/'
+
+  console.log('Auth confirm params:', { token_hash, token, code, type, next })
+
+  const supabase = await createServerSupabase()
+
+  // Handle different auth flows
+  if (code) {
+    // Handle PKCE flow with authorization code
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error && data.session) {
+      console.log('Code exchange successful')
+      redirect(next)
+    } else {
+      console.error('Code exchange error:', error)
+    }
+  } else if (token_hash && type) {
+    // Handle token_hash flow
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash,
+    })
+
+    if (!error) {
+      console.log('Token hash verification successful')
+      redirect(next)
+    } else {
+      console.error('Token hash verification error:', error)
+    }
+  } else if (token && type) {
+    // Handle token flow
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash: token,
+    })
+
+    if (!error) {
+      console.log('Token verification successful')
+      redirect(next)
+    } else {
+      console.error('Token verification error:', error)
+    }
+  }
+
+  console.log('Auth confirmation failed, redirecting to error')
+  // redirect the user to an error page with some instructions
+  redirect('/error')
+}

--- a/app/error/page.tsx
+++ b/app/error/page.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function ErrorPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-primary/5 to-primary/10">
+      <div className="w-full max-w-md">
+        <div className="bg-background rounded-lg shadow-lg p-8 border text-center space-y-4">
+          <h1 className="text-xl font-semibold text-destructive">
+            오류가 발생했습니다
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            인증 링크가 유효하지 않거나 만료되었습니다. 다시 시도해주세요.
+          </p>
+          <Link href="/forgot-password">
+            <Button className="w-full">
+              비밀번호 재설정 다시 요청
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -285,6 +285,33 @@ const translations: Record<Language, Record<string, string>> = {
     "usage.upgrade.description": "Pro 플랜으로 업그레이드하세요",
     "usage.upgrade.button": "업그레이드",
     "usage.features.title": "현재 플랜 혜택",
+
+    // Forgot Password Page
+    "forgotPassword.title": "비밀번호 찾기",
+    "forgotPassword.subtitle": "이메일 주소를 입력하시면 비밀번호 재설정 링크를 보내드립니다.",
+    "forgotPassword.emailLabel": "이메일 주소",
+    "forgotPassword.sendReset": "재설정 링크 보내기",
+    "forgotPassword.sending": "전송 중...",
+    "forgotPassword.backToLogin": "로그인으로 돌아가기",
+    "forgotPassword.checkEmail": "이메일을 확인하세요",
+    "forgotPassword.emailSentMessage": "비밀번호 재설정 링크가 이메일로 전송되었습니다.",
+    "forgotPassword.checkInbox": "이메일 받은함을 확인하시고 링크를 클릭하여 비밀번호를 재설정하세요.",
+    "forgotPassword.didntReceive": "이메일을 받지 못하셨나요?",
+    "forgotPassword.sendAnother": "다시 보내기",
+
+    // Reset Password Page
+    "resetPassword.title": "새 비밀번호 설정",
+    "resetPassword.subtitle": "새로운 비밀번호를 입력하세요.",
+    "resetPassword.newPassword": "새 비밀번호",
+    "resetPassword.confirmPassword": "비밀번호 확인",
+    "resetPassword.updatePassword": "비밀번호 업데이트",
+    "resetPassword.updating": "업데이트 중...",
+    "resetPassword.backToLogin": "로그인으로 돌아가기",
+    "resetPassword.invalidLink": "유효하지 않은 링크",
+    "resetPassword.invalidLinkMessage": "이 링크는 유효하지 않거나 만료되었습니다. 새로운 비밀번호 재설정을 요청해주세요.",
+    "resetPassword.requestNew": "새 재설정 링크 요청",
+    "resetPassword.successTitle": "비밀번호가 변경되었습니다",
+    "resetPassword.successMessage": "새 비밀번호로 로그인해주세요. 잠시 후 로그인 페이지로 이동합니다.",
   },
   en: {
     // Header
@@ -548,6 +575,33 @@ const translations: Record<Language, Record<string, string>> = {
     "usage.upgrade.description": "Upgrade to Pro plan",
     "usage.upgrade.button": "Upgrade",
     "usage.features.title": "Current Plan Benefits",
+
+    // Forgot Password Page
+    "forgotPassword.title": "Forgot Password",
+    "forgotPassword.subtitle": "Enter your email address and we'll send you a password reset link.",
+    "forgotPassword.emailLabel": "Email Address",
+    "forgotPassword.sendReset": "Send Reset Link",
+    "forgotPassword.sending": "Sending...",
+    "forgotPassword.backToLogin": "Back to Login",
+    "forgotPassword.checkEmail": "Check Your Email",
+    "forgotPassword.emailSentMessage": "A password reset link has been sent to your email.",
+    "forgotPassword.checkInbox": "Please check your inbox and click the link to reset your password.",
+    "forgotPassword.didntReceive": "Didn't receive an email?",
+    "forgotPassword.sendAnother": "Send Another",
+
+    // Reset Password Page
+    "resetPassword.title": "Set New Password",
+    "resetPassword.subtitle": "Enter your new password below.",
+    "resetPassword.newPassword": "New Password",
+    "resetPassword.confirmPassword": "Confirm Password",
+    "resetPassword.updatePassword": "Update Password",
+    "resetPassword.updating": "Updating...",
+    "resetPassword.backToLogin": "Back to Login",
+    "resetPassword.invalidLink": "Invalid Link",
+    "resetPassword.invalidLinkMessage": "This link is invalid or has expired. Please request a new password reset.",
+    "resetPassword.requestNew": "Request New Reset Link",
+    "resetPassword.successTitle": "Password Changed Successfully",
+    "resetPassword.successMessage": "Please log in with your new password. You will be redirected to the login page shortly.",
   },
 };
 

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -10,6 +10,8 @@ const publicRoutes: Routes = {
   "/auth": true,
   "/error": true,
   "/": true,
+  "/forgot-password": true,
+  "/reset-password": true,
 };
 
 // Routes that should redirect to dashboard if user is authenticated
@@ -26,6 +28,9 @@ function isPublicRoute(pathname: string): boolean {
 
   // Check if it's a sign route (public for external users)
   if (pathname.startsWith("/sign/")) return true;
+
+  // Check if it's an auth route (including auth/confirm, auth/callback, etc.)
+  if (pathname.startsWith("/auth/")) return true;
 
   return false;
 }

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -42,3 +42,4 @@ export function createServiceSupabase() {
     }
   );
 }
+


### PR DESCRIPTION
handling, UI states and success flow. new page includes:
- a password reset form wired to the resetPassword action using useFormState and server action dispatching
- toggles to show/hide password and confirm-password inputs
- validation props (minLength, required) and field error display
- success screen with icon, message, and auto-redirect to /login after 3s plus a "Back to login" button
- accessible labels, icons, and shared UI components (Button, Input, Label, Alert, SubmitButton) and translations via useLanguage

Remove unused page metadata from auth/register/page.tsx to avoid duplicated metadata declarations and simplify the Register route file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 비밀번호 찾기/재설정 플로우 추가: 이메일 입력·성공 화면, 새 비밀번호 설정, 로그인으로 이동 링크 제공
  - 인증 확인 경로 추가: 이메일/코드 확인 후 지정 위치로 리디렉션
  - 잘못되었거나 만료된 링크용 에러 페이지 추가
- Refactor
  - 요금제 카드 정렬을 플랜의 order 값 기준으로 변경
- Chores
  - ko/en 번역 키 대거 추가(비밀번호 관련 화면 포함)
  - 공개 경로에 /forgot-password, /reset-password 및 /auth/* 추가
  - 일부 페이지의 메타데이터 내보내기 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->