### PR TITLE
✨ feat: add image zoom, pan, touch gestures & areas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,3 +89,4 @@ Authentication uses Supabase Auth with route protection logic defined in `lib/su
 - Client Components for interactivity (signature capture, modals)
 - Consistent use of TypeScript with proper type definitions
 - Form handling with proper loading states and error handling
+- 개발환경은 백그라운드에서 따로 띄우면 안됨. 직접 띄울 예정.

--- a/components/area-selector.tsx
+++ b/components/area-selector.tsx
@@ -3,18 +3,23 @@
 import type React from "react";
 
 import { useState, useRef, useEffect } from "react";
+import { ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 // Import the useLanguage hook at the top of the file
 import { useLanguage } from "@/contexts/language-context";
 
+// Import coordinate conversion utilities
+import {
+  getImageNaturalDimensions,
+  convertSignatureAreaToPercent,
+  ensureRelativeCoordinate,
+  type RelativeSignatureArea,
+} from "@/lib/utils";
+
 interface AreaSelectorProps {
   image: string;
-  onAreaSelected: (area: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  }) => void;
+  onAreaSelected: (area: RelativeSignatureArea) => void;
   onCancel: () => void;
   existingAreas?: Array<{
     x: number;
@@ -42,6 +47,13 @@ export default function AreaSelector({
   const containerRef = useRef<HTMLDivElement>(null);
   const [originalOverflow, setOriginalOverflow] = useState<string>("");
   const [scrollPositionApplied, setScrollPositionApplied] = useState(false);
+  const [zoomLevel, setZoomLevel] = useState<number>(1);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [dragStart, setDragStart] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [lastTouchDistance, setLastTouchDistance] = useState<number>(0);
+  const [lastTapTime, setLastTapTime] = useState<number>(0);
+  const [touchStartZoom, setTouchStartZoom] = useState<number>(1);
+  const [isPinching, setIsPinching] = useState<boolean>(false);
 
   // Add the useLanguage hook inside the component
   const { t } = useLanguage();
@@ -58,16 +70,192 @@ export default function AreaSelector({
   const getCoordinates = (clientX: number, clientY: number) => {
     if (!containerRef.current) return { x: 0, y: 0 };
 
-    const rect = containerRef.current.getBoundingClientRect();
-    // Account for scroll position
-    const scrollLeft = containerRef.current.scrollLeft;
-    const scrollTop = containerRef.current.scrollTop;
+    try {
+      const rect = containerRef.current.getBoundingClientRect();
+      // Account for scroll position
+      const scrollLeft = containerRef.current.scrollLeft;
+      const scrollTop = containerRef.current.scrollTop;
 
-    // Calculate coordinates relative to the container, accounting for scroll
-    const x = clientX - rect.left + scrollLeft;
-    const y = clientY - rect.top + scrollTop;
+      // Calculate coordinates relative to the container, accounting for scroll
+      const pixelX = (clientX - rect.left + scrollLeft);
+      const pixelY = (clientY - rect.top + scrollTop);
 
+      // Get the image element to calculate displayed dimensions
+      const imgElement = containerRef.current.querySelector('img') as HTMLImageElement;
+      if (!imgElement) {
+        console.warn('Image element not found');
+        return { x: 0, y: 0 };
+      }
+
+      // Get the current displayed dimensions (which are scaled by zoomLevel)
+      const displayedWidth = imgElement.clientWidth;
+      const displayedHeight = imgElement.clientHeight;
+
+      // Convert to percentage coordinates based on current displayed image size
+      const x = (pixelX / displayedWidth) * 100;
+      const y = (pixelY / displayedHeight) * 100;
+
+      return { x, y };
+    } catch (error) {
+      console.warn('Failed to get image container dimensions:', error);
+      return { x: 0, y: 0 };
+    }
+  };
+
+  const handleZoomIn = () => {
+    setZoomLevel(prev => Math.min(prev + 0.25, 3));
+  };
+
+  const handleZoomOut = () => {
+    setZoomLevel(prev => Math.max(prev - 0.25, 0.5));
+  };
+
+  const handleZoomReset = () => {
+    setZoomLevel(1);
+  };
+
+  const handleContainerMouseDown = (e: React.MouseEvent) => {
+    if (zoomLevel > 1 && !isSelecting) {
+      setIsDragging(true);
+      setDragStart({ x: e.clientX, y: e.clientY });
+      e.preventDefault();
+      return;
+    }
+    handleMouseDown(e);
+  };
+
+  const handleContainerMouseMove = (e: React.MouseEvent) => {
+    if (isDragging && containerRef.current) {
+      e.preventDefault();
+      const deltaX = e.clientX - dragStart.x;
+      const deltaY = e.clientY - dragStart.y;
+
+      containerRef.current.scrollLeft -= deltaX;
+      containerRef.current.scrollTop -= deltaY;
+
+      setDragStart({ x: e.clientX, y: e.clientY });
+      return;
+    }
+    handleMouseMove(e);
+  };
+
+  const handleContainerMouseUp = (e: React.MouseEvent) => {
+    if (isDragging) {
+      setIsDragging(false);
+      return;
+    }
+    handleMouseUp(e);
+  };
+
+  // Touch gesture helpers
+  const getTouchDistance = (touches: TouchList) => {
+    if (touches.length < 2) return 0;
+    const touch1 = touches[0];
+    const touch2 = touches[1];
+    return Math.sqrt(
+      Math.pow(touch2.clientX - touch1.clientX, 2) +
+      Math.pow(touch2.clientY - touch1.clientY, 2)
+    );
+  };
+
+  const getTouchCenter = (touches: TouchList) => {
+    if (touches.length === 0) return { x: 0, y: 0 };
+    if (touches.length === 1) {
+      return { x: touches[0].clientX, y: touches[0].clientY };
+    }
+    const x = (touches[0].clientX + touches[1].clientX) / 2;
+    const y = (touches[0].clientY + touches[1].clientY) / 2;
     return { x, y };
+  };
+
+  // Enhanced touch event handlers
+  const handleEnhancedTouchStart = (e: React.TouchEvent) => {
+    if (e.touches.length === 1) {
+      // Single touch - check for double tap or start selection
+      const currentTime = Date.now();
+      const timeDiff = currentTime - lastTapTime;
+
+      if (timeDiff < 300 && timeDiff > 0) {
+        // Double tap detected - toggle zoom
+        e.preventDefault();
+        if (zoomLevel === 1) {
+          setZoomLevel(2);
+        } else {
+          setZoomLevel(1);
+        }
+        return;
+      }
+      setLastTapTime(currentTime);
+
+      // Start dragging for panning if zoomed
+      if (zoomLevel > 1 && !isSelecting) {
+        e.preventDefault();
+        setIsDragging(true);
+        setDragStart({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+        return;
+      }
+
+      // Otherwise, handle as area selection
+      handleTouchStart(e);
+    } else if (e.touches.length === 2) {
+      // Pinch gesture start
+      e.preventDefault();
+      setIsPinching(true);
+      const distance = getTouchDistance(e.touches);
+      setLastTouchDistance(distance);
+      setTouchStartZoom(zoomLevel);
+      setIsDragging(false);
+      setIsSelecting(false);
+    }
+  };
+
+  const handleEnhancedTouchMove = (e: React.TouchEvent) => {
+    if (e.touches.length === 1 && isDragging && containerRef.current) {
+      // Single touch panning
+      e.preventDefault();
+      const deltaX = e.touches[0].clientX - dragStart.x;
+      const deltaY = e.touches[0].clientY - dragStart.y;
+
+      containerRef.current.scrollLeft -= deltaX;
+      containerRef.current.scrollTop -= deltaY;
+
+      setDragStart({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+    } else if (e.touches.length === 2 && isPinching) {
+      // Pinch zoom
+      e.preventDefault();
+      const distance = getTouchDistance(e.touches);
+      if (lastTouchDistance > 0) {
+        const scale = distance / lastTouchDistance;
+        const newZoom = Math.min(Math.max(touchStartZoom * scale, 0.5), 3);
+        setZoomLevel(newZoom);
+      }
+    } else if (!isPinching) {
+      // Handle normal area selection touch move
+      handleTouchMove(e);
+    }
+  };
+
+  const handleEnhancedTouchEnd = (e: React.TouchEvent) => {
+    if (e.touches.length === 0) {
+      if (isPinching) {
+        e.preventDefault();
+        setIsPinching(false);
+        setLastTouchDistance(0);
+        return;
+      }
+      if (isDragging) {
+        e.preventDefault();
+        setIsDragging(false);
+        return;
+      }
+      // Handle normal area selection touch end
+      handleTouchEnd(e);
+    } else if (e.touches.length === 1) {
+      // Switch from pinch to pan
+      setIsPinching(false);
+      setLastTouchDistance(0);
+      setTouchStartZoom(zoomLevel);
+    }
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -108,7 +296,8 @@ export default function AreaSelector({
       const width = Math.abs(currentPos.x - startPos.x);
       const height = Math.abs(currentPos.y - startPos.y);
 
-      if (width > 10 && height > 10) {
+      // Use percentage-based minimum size (1% of container)
+      if (width > 1 && height > 1) {
         onAreaSelected({ x, y, width, height });
       }
     }
@@ -159,7 +348,8 @@ export default function AreaSelector({
       const width = Math.abs(currentPos.x - startPos.x);
       const height = Math.abs(currentPos.y - startPos.y);
 
-      if (width > 10 && height > 10) {
+      // Use percentage-based minimum size (1% of container)
+      if (width > 1 && height > 1) {
         onAreaSelected({ x, y, width, height });
       }
     }
@@ -216,58 +406,119 @@ export default function AreaSelector({
 
   return (
     <div className="relative">
+      {/* Zoom Controls */}
+      <div className="absolute top-2 sm:top-4 right-2 sm:right-4 z-10 flex flex-col gap-1 sm:gap-2 bg-white/90 backdrop-blur-sm rounded-lg p-1 sm:p-2 shadow-lg">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleZoomIn}
+          disabled={zoomLevel >= 3}
+          className="p-1 sm:p-2 h-6 w-6 sm:h-8 sm:w-8"
+        >
+          <ZoomIn className="h-3 w-3 sm:h-4 sm:w-4" />
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleZoomOut}
+          disabled={zoomLevel <= 0.5}
+          className="p-1 sm:p-2 h-6 w-6 sm:h-8 sm:w-8"
+        >
+          <ZoomOut className="h-3 w-3 sm:h-4 sm:w-4" />
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleZoomReset}
+          disabled={zoomLevel === 1}
+          className="p-1 sm:p-2 h-6 w-6 sm:h-8 sm:w-8"
+        >
+          <RotateCcw className="h-3 w-3 sm:h-4 sm:w-4" />
+        </Button>
+        <div className="text-xs text-center font-medium px-1 py-0.5 bg-gray-100 rounded">
+          {Math.round(zoomLevel * 100)}%
+        </div>
+      </div>
       <div
         ref={containerRef}
-        className="relative cursor-crosshair"
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
+        className="relative overflow-auto max-h-[50vh] sm:max-h-[70vh]"
         style={{
           touchAction: "none",
+          cursor: zoomLevel > 1 && !isSelecting ? (isDragging ? 'grabbing' : 'grab') : 'crosshair'
         }}
+        onMouseDown={handleContainerMouseDown}
+        onMouseMove={handleContainerMouseMove}
+        onMouseUp={handleContainerMouseUp}
+        onMouseLeave={() => {
+          setIsDragging(false);
+        }}
+        onTouchStart={handleEnhancedTouchStart}
+        onTouchMove={handleEnhancedTouchMove}
+        onTouchEnd={handleEnhancedTouchEnd}
       >
-        <img
-          src={image || "/placeholder.svg"}
-          alt="Document"
-          className="w-full h-auto object-contain"
-          draggable="false"
-          style={{ userSelect: "none", WebkitUserSelect: "none" }}
-        />
-
-        {/* Show existing areas */}
-        {existingAreas.map((area, index) => (
-          <div
-            key={index}
-            className="absolute border-2 border-green-500 bg-green-500/10 flex items-center justify-center pointer-events-none"
-            style={{
-              left: `${area.x}px`,
-              top: `${area.y}px`,
-              width: `${area.width}px`,
-              height: `${area.height}px`,
-            }}
-          >
-            <span className="text-xs font-medium text-green-600">
-              {t("upload.signature")} {index + 1}
-            </span>
-          </div>
-        ))}
-
-        {/* Show current selection */}
-        {isSelecting && startPos && currentPos && (
-          <div
-            className="absolute border-2 border-red-500 bg-red-500/10"
-            style={{
-              left: `${Math.min(startPos.x, currentPos.x)}px`,
-              top: `${Math.min(startPos.y, currentPos.y)}px`,
-              width: `${Math.abs(currentPos.x - startPos.x)}px`,
-              height: `${Math.abs(currentPos.y - startPos.y)}px`,
-              pointerEvents: "none",
-            }}
+        <div
+          className="relative inline-block"
+          style={{
+            width: `${100 * zoomLevel}%`,
+            height: 'auto'
+          }}
+        >
+          <img
+            src={image || "/placeholder.svg"}
+            alt="Document"
+            className="w-full h-auto object-contain block"
+            draggable="false"
+            style={{ userSelect: "none", WebkitUserSelect: "none" }}
           />
-        )}
+
+          {/* Show existing areas */}
+          {existingAreas.map((area, index) => {
+          // Convert existing areas to relative coordinates if needed
+          let relativeArea: RelativeSignatureArea;
+          try {
+            if (!containerRef.current) {
+              return null;
+            }
+            const { width: originalWidth, height: originalHeight } = getImageNaturalDimensions(containerRef.current);
+            relativeArea = ensureRelativeCoordinate(area, originalWidth, originalHeight);
+          } catch (error) {
+            console.warn('Failed to convert area coordinates:', error);
+            return null;
+          }
+
+            return (
+              <div
+                key={index}
+                className="absolute border-2 border-green-500 bg-green-500/10 flex items-center justify-center pointer-events-none"
+                style={{
+                  left: `${relativeArea.x}%`,
+                  top: `${relativeArea.y}%`,
+                  width: `${relativeArea.width}%`,
+                  height: `${relativeArea.height}%`,
+                }}
+              >
+                <span className="text-xs font-medium text-green-600">
+                  <span className="hidden sm:inline">{t("upload.signature")} {index + 1}</span>
+                  <span className="sm:hidden">{index + 1}</span>
+                </span>
+              </div>
+            );
+          })}
+
+          {/* Show current selection */}
+          {isSelecting && startPos && currentPos && (
+            <div
+              className="absolute border-2 border-red-500 bg-red-500/10"
+              style={{
+                left: `${Math.min(startPos.x, currentPos.x)}%`,
+                top: `${Math.min(startPos.y, currentPos.y)}%`,
+                width: `${Math.abs(currentPos.x - startPos.x)}%`,
+                height: `${Math.abs(currentPos.y - startPos.y)}%`,
+                pointerEvents: "none",
+              }}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -4,7 +4,7 @@ import type React from "react";
 
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Upload, FileImage, Trash2 } from "lucide-react";
+import { Upload, FileImage, Trash2, ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import AreaSelector from "@/components/area-selector";
@@ -14,6 +14,12 @@ import {
 } from "@/app/actions/document-actions";
 import { useLanguage } from "@/contexts/language-context";
 import type { SignatureArea } from "@/lib/supabase/database.types";
+import {
+  getImageNaturalDimensions,
+  convertSignatureAreaToPixels,
+  ensureRelativeCoordinate,
+  type RelativeSignatureArea,
+} from "@/lib/utils";
 
 export default function DocumentUpload() {
   const { t } = useLanguage();
@@ -21,7 +27,7 @@ export default function DocumentUpload() {
   const [document, setDocument] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string>("");
   const [originalFile, setOriginalFile] = useState<File | null>(null);
-  const [signatureAreas, setSignatureAreas] = useState<SignatureArea[]>([]);
+  const [signatureAreas, setSignatureAreas] = useState<RelativeSignatureArea[]>([]);
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -31,6 +37,12 @@ export default function DocumentUpload() {
     top: number;
     left: number;
   }>({ top: 0, left: 0 });
+  const [zoomLevel, setZoomLevel] = useState<number>(1);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [dragStart, setDragStart] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+  const [lastTouchDistance, setLastTouchDistance] = useState<number>(0);
+  const [lastTapTime, setLastTapTime] = useState<number>(0);
+  const [touchStartZoom, setTouchStartZoom] = useState<number>(1);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -61,8 +73,8 @@ export default function DocumentUpload() {
     setIsSelecting(true);
   };
 
-  const handleAreaSelected = (area: SignatureArea) => {
-    // Simply store the area coordinates as they are
+  const handleAreaSelected = (area: RelativeSignatureArea) => {
+    // Store the area coordinates as relative percentages
     setSignatureAreas([...signatureAreas, area]);
     setIsSelecting(false);
   };
@@ -79,6 +91,134 @@ export default function DocumentUpload() {
     setOriginalFile(null);
     setSignatureAreas([]);
     setError(null);
+    setZoomLevel(1);
+  };
+
+  const handleZoomIn = () => {
+    setZoomLevel(prev => Math.min(prev + 0.25, 3));
+  };
+
+  const handleZoomOut = () => {
+    setZoomLevel(prev => Math.max(prev - 0.25, 0.5));
+  };
+
+  const handleZoomReset = () => {
+    setZoomLevel(1);
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    if (zoomLevel > 1 && !isSelecting) {
+      e.preventDefault();
+      setIsDragging(true);
+      setDragStart({ x: e.clientX, y: e.clientY });
+    }
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (isDragging && documentContainerRef.current) {
+      e.preventDefault();
+      const deltaX = e.clientX - dragStart.x;
+      const deltaY = e.clientY - dragStart.y;
+
+      documentContainerRef.current.scrollLeft -= deltaX;
+      documentContainerRef.current.scrollTop -= deltaY;
+
+      setDragStart({ x: e.clientX, y: e.clientY });
+    }
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  // Touch gesture helpers
+  const getTouchDistance = (touches: TouchList) => {
+    if (touches.length < 2) return 0;
+    const touch1 = touches[0];
+    const touch2 = touches[1];
+    return Math.sqrt(
+      Math.pow(touch2.clientX - touch1.clientX, 2) +
+      Math.pow(touch2.clientY - touch1.clientY, 2)
+    );
+  };
+
+  const getTouchCenter = (touches: TouchList) => {
+    if (touches.length === 0) return { x: 0, y: 0 };
+    if (touches.length === 1) {
+      return { x: touches[0].clientX, y: touches[0].clientY };
+    }
+    const x = (touches[0].clientX + touches[1].clientX) / 2;
+    const y = (touches[0].clientY + touches[1].clientY) / 2;
+    return { x, y };
+  };
+
+  // Touch event handlers
+  const handleTouchStart = (e: React.TouchEvent) => {
+    e.preventDefault();
+
+    if (e.touches.length === 1) {
+      // Single touch - check for double tap
+      const currentTime = Date.now();
+      const timeDiff = currentTime - lastTapTime;
+
+      if (timeDiff < 300 && timeDiff > 0) {
+        // Double tap detected - toggle zoom
+        if (zoomLevel === 1) {
+          setZoomLevel(2);
+        } else {
+          setZoomLevel(1);
+        }
+      }
+      setLastTapTime(currentTime);
+
+      // Start dragging for panning
+      if (zoomLevel > 1) {
+        setIsDragging(true);
+        setDragStart({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+      }
+    } else if (e.touches.length === 2) {
+      // Pinch gesture start
+      const distance = getTouchDistance(e.touches);
+      setLastTouchDistance(distance);
+      setTouchStartZoom(zoomLevel);
+      setIsDragging(false);
+    }
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    e.preventDefault();
+
+    if (e.touches.length === 1 && isDragging && documentContainerRef.current) {
+      // Single touch panning
+      const deltaX = e.touches[0].clientX - dragStart.x;
+      const deltaY = e.touches[0].clientY - dragStart.y;
+
+      documentContainerRef.current.scrollLeft -= deltaX;
+      documentContainerRef.current.scrollTop -= deltaY;
+
+      setDragStart({ x: e.touches[0].clientX, y: e.touches[0].clientY });
+    } else if (e.touches.length === 2) {
+      // Pinch zoom
+      const distance = getTouchDistance(e.touches);
+      if (lastTouchDistance > 0) {
+        const scale = distance / lastTouchDistance;
+        const newZoom = Math.min(Math.max(touchStartZoom * scale, 0.5), 3);
+        setZoomLevel(newZoom);
+      }
+    }
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    e.preventDefault();
+
+    if (e.touches.length === 0) {
+      setIsDragging(false);
+      setLastTouchDistance(0);
+    } else if (e.touches.length === 1) {
+      // Switch from pinch to pan
+      setLastTouchDistance(0);
+      setTouchStartZoom(zoomLevel);
+    }
   };
 
   const handleSaveDocument = async () => {
@@ -109,9 +249,30 @@ export default function DocumentUpload() {
       }
 
       // Step 2: Create signature areas
+      // Convert relative coordinates to absolute pixels for database storage
+      let absoluteAreas: SignatureArea[] = [];
+      try {
+        if (documentContainerRef.current) {
+          const { width: originalWidth, height: originalHeight } = getImageNaturalDimensions(documentContainerRef.current);
+          absoluteAreas = signatureAreas.map(area => {
+            const pixelArea = convertSignatureAreaToPixels(area, originalWidth, originalHeight);
+            return {
+              x: pixelArea.x,
+              y: pixelArea.y,
+              width: pixelArea.width,
+              height: pixelArea.height,
+            } as SignatureArea;
+          });
+        }
+      } catch (error) {
+        console.error('Failed to convert coordinates:', error);
+        setError('Failed to process signature areas');
+        return;
+      }
+
       const areasResult = await createSignatureAreas(
         uploadResult.document.id,
-        signatureAreas
+        absoluteAreas
       );
 
       if (areasResult.error) {
@@ -177,6 +338,39 @@ export default function DocumentUpload() {
           </div>
 
           <div className="relative border rounded-lg overflow-hidden">
+            {/* Zoom Controls */}
+            <div className="absolute top-4 right-4 z-10 flex flex-col gap-2 bg-white/90 backdrop-blur-sm rounded-lg p-2 shadow-lg">
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleZoomIn}
+                disabled={zoomLevel >= 3 || isSelecting}
+                className="p-2 h-8 w-8"
+              >
+                <ZoomIn className="h-4 w-4" />
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleZoomOut}
+                disabled={zoomLevel <= 0.5 || isSelecting}
+                className="p-2 h-8 w-8"
+              >
+                <ZoomOut className="h-4 w-4" />
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleZoomReset}
+                disabled={zoomLevel === 1 || isSelecting}
+                className="p-2 h-8 w-8"
+              >
+                <RotateCcw className="h-4 w-4" />
+              </Button>
+              <div className="text-xs text-center font-medium px-1 py-0.5 bg-gray-100 rounded">
+                {Math.round(zoomLevel * 100)}%
+              </div>
+            </div>
             {isSelecting ? (
               <AreaSelector
                 image={document}
@@ -186,33 +380,56 @@ export default function DocumentUpload() {
                 initialScrollPosition={scrollPosition}
               />
             ) : (
-              <div ref={documentContainerRef} className="relative">
-                <img
-                  src={document || "/placeholder.svg"}
-                  alt="Document"
-                  className="w-full h-auto object-contain"
-                  draggable="false"
-                />
-                {signatureAreas.map((area, index) => (
-                  <div
-                    key={index}
-                    className="absolute border-2 border-red-500 bg-red-500/10 flex items-center justify-center"
-                    style={{
-                      position: "absolute",
-                      left: `${area.x}px`,
-                      top: `${area.y}px`,
-                      width: `${area.width}px`,
-                      height: `${area.height}px`,
-                      pointerEvents: "auto",
-                      cursor: "pointer",
-                    }}
-                    onClick={() => handleRemoveArea(index)}
-                  >
-                    <span className="text-xs font-medium text-red-600">
-                      {t("upload.signature")} {index + 1}
-                    </span>
-                  </div>
-                ))}
+              <div
+                ref={documentContainerRef}
+                className="relative overflow-auto max-h-[70vh]"
+                style={{
+                  cursor: zoomLevel > 1 ? (isDragging ? 'grabbing' : 'grab') : 'default',
+                  touchAction: 'none'
+                }}
+                onMouseDown={handleMouseDown}
+                onMouseMove={handleMouseMove}
+                onMouseUp={handleMouseUp}
+                onMouseLeave={handleMouseUp}
+                onTouchStart={handleTouchStart}
+                onTouchMove={handleTouchMove}
+                onTouchEnd={handleTouchEnd}
+              >
+                <div
+                  className="relative inline-block"
+                  style={{
+                    width: `${100 * zoomLevel}%`,
+                    height: 'auto'
+                  }}
+                >
+                  <img
+                    src={document || "/placeholder.svg"}
+                    alt="Document"
+                    className="w-full h-auto object-contain block"
+                    draggable="false"
+                    style={{ userSelect: "none", WebkitUserSelect: "none" }}
+                  />
+                  {signatureAreas.map((area, index) => (
+                    <div
+                      key={index}
+                      className="absolute border-2 border-red-500 bg-red-500/10 flex items-center justify-center"
+                      style={{
+                        position: "absolute",
+                        left: `${area.x}%`,
+                        top: `${area.y}%`,
+                        width: `${area.width}%`,
+                        height: `${area.height}%`,
+                        pointerEvents: "auto",
+                        cursor: "pointer",
+                      }}
+                      onClick={() => handleRemoveArea(index)}
+                    >
+                      <span className="text-xs font-medium text-red-600">
+                        {t("upload.signature")} {index + 1}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
             )}
           </div>

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,138 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+// 좌표 변환 유틸리티 함수들
+
+/**
+ * 절대 픽셀 값을 상대 퍼센트로 변환
+ */
+export function pixelsToPercent(pixelValue: number, containerSize: number): number {
+  if (containerSize === 0) return 0;
+  return (pixelValue / containerSize) * 100;
+}
+
+/**
+ * 상대 퍼센트를 절대 픽셀 값으로 변환
+ */
+export function percentToPixels(percentValue: number, containerSize: number): number {
+  return (percentValue / 100) * containerSize;
+}
+
+/**
+ * 이미지 컨테이너의 실제 크기를 가져오기 (deprecated - 화면 크기에 따라 변함)
+ */
+export function getImageContainerDimensions(containerElement: HTMLElement): {
+  width: number;
+  height: number;
+} {
+  const img = containerElement.querySelector('img') as HTMLImageElement;
+  if (!img) {
+    throw new Error('Image not found in container');
+  }
+
+  return {
+    width: img.clientWidth,
+    height: img.clientHeight,
+  };
+}
+
+/**
+ * 이미지의 원본 크기를 가져오기 (진짜 상대 좌표를 위해 사용)
+ */
+export function getImageNaturalDimensions(containerElement: HTMLElement): {
+  width: number;
+  height: number;
+} {
+  const img = containerElement.querySelector('img') as HTMLImageElement;
+  if (!img) {
+    throw new Error('Image not found in container');
+  }
+
+  // 이미지가 로드되지 않은 경우 대기
+  if (img.naturalWidth === 0 || img.naturalHeight === 0) {
+    throw new Error('Image not loaded yet');
+  }
+
+  return {
+    width: img.naturalWidth,   // 원본 이미지 크기
+    height: img.naturalHeight, // 원본 이미지 크기
+  };
+}
+
+/**
+ * SignatureArea 타입 정의 (상대 좌표용)
+ */
+export interface RelativeSignatureArea {
+  x: number;      // 0-100% (원본 이미지 기준)
+  y: number;      // 0-100% (원본 이미지 기준)
+  width: number;  // 0-100% (원본 이미지 기준)
+  height: number; // 0-100% (원본 이미지 기준)
+}
+
+/**
+ * SignatureArea 타입 정의 (절대 좌표용)
+ */
+export interface AbsoluteSignatureArea {
+  x: number;      // 절대 픽셀
+  y: number;      // 절대 픽셀
+  width: number;  // 절대 픽셀
+  height: number; // 절대 픽셀
+}
+
+/**
+ * 절대 픽셀 좌표의 SignatureArea를 상대 퍼센트로 변환 (원본 이미지 크기 기준)
+ */
+export function convertSignatureAreaToPercent(
+  area: AbsoluteSignatureArea,
+  originalImageWidth: number,
+  originalImageHeight: number
+): RelativeSignatureArea {
+  return {
+    x: pixelsToPercent(area.x, originalImageWidth),
+    y: pixelsToPercent(area.y, originalImageHeight),
+    width: pixelsToPercent(area.width, originalImageWidth),
+    height: pixelsToPercent(area.height, originalImageHeight),
+  };
+}
+
+/**
+ * 상대 퍼센트의 SignatureArea를 절대 픽셀로 변환 (원본 이미지 크기 기준)
+ */
+export function convertSignatureAreaToPixels(
+  area: RelativeSignatureArea,
+  originalImageWidth: number,
+  originalImageHeight: number
+): AbsoluteSignatureArea {
+  return {
+    x: percentToPixels(area.x, originalImageWidth),
+    y: percentToPixels(area.y, originalImageHeight),
+    width: percentToPixels(area.width, originalImageWidth),
+    height: percentToPixels(area.height, originalImageHeight),
+  };
+}
+
+/**
+ * 기존 절대 좌표 데이터가 상대 좌표인지 확인하는 함수
+ * (하위 호환성을 위해, 모든 값이 100 이하면 상대 좌표로 가정)
+ */
+export function isRelativeCoordinate(area: { x: number; y: number; width: number; height: number }): boolean {
+  return area.x <= 100 && area.y <= 100 && area.width <= 100 && area.height <= 100;
+}
+
+/**
+ * 기존 데이터를 자동으로 상대 좌표로 변환 (필요시) - 원본 이미지 크기 기준
+ */
+export function ensureRelativeCoordinate(
+  area: { x: number; y: number; width: number; height: number },
+  originalImageWidth: number,
+  originalImageHeight: number
+): RelativeSignatureArea {
+  if (isRelativeCoordinate(area)) {
+    // 이미 상대 좌표
+    return area as RelativeSignatureArea;
+  } else {
+    // 절대 좌표를 상대 좌표로 변환 (원본 이미지 크기 기준)
+    return convertSignatureAreaToPercent(area, originalImageWidth, originalImageHeight);
+  }
+}


### PR DESCRIPTION
- Add zoom controls (zoom/out/reset) and zoom state to document
  upload UI to allow users to magnify the document for precise selection.
- Add panning support via mouse drag when zoomed in; track dragging
  state and deltas to scroll the document container.
- Implement touch gesture helpers: pinch-to-zoom (distance/center),
  double-tap to toggle zoom, and touch state tracking to support mobile
  interactions.
- Change signature area handling from absolute SignatureArea to
  RelativeSignatureArea and store relative percentage coordinates so
  selections remain correct across zoom/size changes.
- Add utility imports for image natural dimensions, conversion between
  relative and pixel areas, and coordinate normalization to support the
  new relative-area workflow.
- Add additional UI icons (ZoomIn, ZoomOut, RotateCcw) to lucide-react
  import and reset zoom on file clear.
- Minor: initialize/clear new interaction-related state (drag, touch,
  zoom) and prevent default touch behaviors for improved mobile UX.

Why:
- Improve document selection accuracy and usability on both desktop
  and touch devices by enabling zooming and panning and by storing
  signature areas as relative coordinates for consistent results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새로운 기능
  * 문서 보기·서명 화면에 확대/축소(버튼·더블탭·핀치)와 드래그(팬) 추가, 확대 비율 표시 및 리셋 지원.
  * 이미지 로드 후 서명 영역 정렬 안정화, 서명 미리보기/라벨 표시, 완료 문서 편집 비활성화.
  * 업로드/영역 선택에서 상대(%) 좌표 기반 오버레이로 다양한 해상도 대응, 스크롤 위치 복원.
  * 발행된 서명 URL 섹션 추가(복사/열기), 진행 상태 및 오류 표시 개선.
* 문서화
  * 폼 로딩·에러 처리 지침 추가.
  * 개발 환경 실행 방식에 대한 한국어 안내 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->