### PR TITLE
✨ feat: enable touch panning when content overflows container

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -312,7 +312,7 @@ export default function DocumentDetailComponent({
       container.scrollHeight > container.clientHeight
     );
 
-    if (canScroll) {
+    if (canScroll && !isSelecting) {
       e.preventDefault();
       setIsDragging(true);
       setDragStart({ x: e.clientX, y: e.clientY });
@@ -333,6 +333,39 @@ export default function DocumentDetailComponent({
   };
 
   const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  // Touch event handlers for mobile support
+  const handleTouchStart = (e: React.TouchEvent) => {
+    const container = documentContainerRef.current;
+    const canScroll = container && (
+      container.scrollWidth > container.clientWidth ||
+      container.scrollHeight > container.clientHeight
+    );
+
+    if (canScroll && !isSelecting && e.touches.length === 1) {
+      const touch = e.touches[0];
+      setIsDragging(true);
+      setDragStart({ x: touch.clientX, y: touch.clientY });
+    }
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (isDragging && documentContainerRef.current && e.touches.length === 1) {
+      e.preventDefault();
+      const touch = e.touches[0];
+      const deltaX = touch.clientX - dragStart.x;
+      const deltaY = touch.clientY - dragStart.y;
+
+      documentContainerRef.current.scrollLeft -= deltaX;
+      documentContainerRef.current.scrollTop -= deltaY;
+
+      setDragStart({ x: touch.clientX, y: touch.clientY });
+    }
+  };
+
+  const handleTouchEnd = () => {
     setIsDragging(false);
   };
 
@@ -656,6 +689,9 @@ export default function DocumentDetailComponent({
               onMouseMove={handleMouseMove}
               onMouseUp={handleMouseUp}
               onMouseLeave={handleMouseUp}
+              onTouchStart={handleTouchStart}
+              onTouchMove={handleTouchMove}
+              onTouchEnd={handleTouchEnd}
             >
               <div
                 className="relative inline-block"

--- a/app/(sign)/sign/[id]/components/SignPage.tsx
+++ b/app/(sign)/sign/[id]/components/SignPage.tsx
@@ -417,8 +417,14 @@ export default function SignPageComponent({
       }
       setLastTapTime(currentTime);
 
-      // Start dragging for panning if zoomed
-      if (zoomLevel > 1) {
+      // Allow dragging when content overflows container
+      const container = documentContainerRef.current;
+      const canScroll = container && (
+        container.scrollWidth > container.clientWidth ||
+        container.scrollHeight > container.clientHeight
+      );
+
+      if (canScroll) {
         e.preventDefault();
         setIsDragging(true);
         setDragStart({ x: e.touches[0].clientX, y: e.touches[0].clientY });
@@ -480,10 +486,17 @@ export default function SignPageComponent({
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
-    if (zoomLevel > 1) {
+    // Allow dragging when content overflows container
+    const container = documentContainerRef.current;
+    const canScroll = container && (
+      container.scrollWidth > container.clientWidth ||
+      container.scrollHeight > container.clientHeight
+    );
+
+    if (canScroll) {
+      e.preventDefault();
       setIsDragging(true);
       setDragStart({ x: e.clientX, y: e.clientY });
-      e.preventDefault();
     }
   };
 


### PR DESCRIPTION
- SignPage replace zoomLevel>1 gate with canScroll check (scrollWidth/scrollHeight > clientWidth/clientHeight) so touch and mouse drag start when content actually overflows.
- SignPage: preserve double-tap zoom logic and existing drag state management while enabling overflow-based panning.
- DocumentDetailPage: add !isSelecting to canScroll guard to avoid starting drag during text selection.
- DocumentDetailPage: add full touch support (handleTouchStart/handleTouchMove/handleTouchEnd) to update scrollLeft/scrollTop and dragStart for mobile panning.
- DocumentDetailPage: wire touch handlers into the container element to enable consistent panning on touch devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 문서 뷰어에 모바일 터치(한 손가락) 패닝 지원 추가.
  * 수평/수직 드래그로 스크롤 가능(컨테이너 오버플로우 시).

* 버그 수정
  * 패닝 시작 조건을 확대 수준(zoom) 대신 콘텐츠 오버플로우 기준으로 통일해, 마우스·터치 모두 일관되게 동작.
  * 선택 모드에서는 드래그 패닝이 시작되지 않도록 제어.

* 기타
  * 문서 상세 및 서명 페이지에 동일한 패닝 로직 적용.
  * 공개 API 변화 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->