### PR TITLE
✨ feat: simplify touch handlers for document view

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -336,32 +336,37 @@ export default function DocumentDetailComponent({
     setIsDragging(false);
   };
 
-  // Touch event handlers for mobile support
+  // Simplified touch event handlers for mobile support
   const handleTouchStart = (e: React.TouchEvent) => {
-    const container = documentContainerRef.current;
-    const canScroll = container && (
-      container.scrollWidth > container.clientWidth ||
-      container.scrollHeight > container.clientHeight
-    );
-
-    if (canScroll && !isSelecting && e.touches.length === 1) {
-      const touch = e.touches[0];
+    if (e.touches.length === 2 && !isSelecting) {
+      // Two finger touch - start document panning
+      e.preventDefault();
       setIsDragging(true);
-      setDragStart({ x: touch.clientX, y: touch.clientY });
+      const touch1 = e.touches[0];
+      const touch2 = e.touches[1];
+      const centerX = (touch1.clientX + touch2.clientX) / 2;
+      const centerY = (touch1.clientY + touch2.clientY) / 2;
+      setDragStart({ x: centerX, y: centerY });
     }
+    // Single touch does nothing in document view mode (unless in selection mode)
   };
 
   const handleTouchMove = (e: React.TouchEvent) => {
-    if (isDragging && documentContainerRef.current && e.touches.length === 1) {
+    if (e.touches.length === 2 && isDragging && documentContainerRef.current) {
+      // Two finger panning
       e.preventDefault();
-      const touch = e.touches[0];
-      const deltaX = touch.clientX - dragStart.x;
-      const deltaY = touch.clientY - dragStart.y;
+      const touch1 = e.touches[0];
+      const touch2 = e.touches[1];
+      const centerX = (touch1.clientX + touch2.clientX) / 2;
+      const centerY = (touch1.clientY + touch2.clientY) / 2;
+      
+      const deltaX = centerX - dragStart.x;
+      const deltaY = centerY - dragStart.y;
 
       documentContainerRef.current.scrollLeft -= deltaX;
       documentContainerRef.current.scrollTop -= deltaY;
 
-      setDragStart({ x: touch.clientX, y: touch.clientY });
+      setDragStart({ x: centerX, y: centerY });
     }
   };
 
@@ -669,6 +674,8 @@ export default function DocumentDetailComponent({
               onCancel={() => setIsSelecting(false)}
               existingAreas={signatureAreas}
               initialScrollPosition={scrollPosition}
+              zoomLevel={zoomLevel}
+              onZoomChange={setZoomLevel}
             />
           ) : (
             <div


### PR DESCRIPTION
Simplify and streamline touch gesture in the document upload component to focus on two-finger panning behavior and remove complex pinch/double-tap logic that not needed in document view- Remove unused touch state: lastTouchDistance, lastTapTime, touchStartZoom.
- Remove helper functions for touch distance/center and pinch/double-tap handling.
- Treat two-finger touch as document panning: compute center point, start dragging, and pan by moving the center between touch events.
- Ignore single-finger gestures in document view (no double-tap or pinch-to-zoom behaviour).
- Properly stop dragging when touches end or reduce to one finger.
- Keep existing mouse dragging and file handling intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AreaSelector가 줌 상태의 외부 제어와 상위 컴포넌트와의 동기화를 지원하여 문서 보기/선택 시 일관된 확대/축소 경험을 제공합니다.

- Refactor
  - 터치 제스처 단순화: 두 손가락 팬만 지원하고, 단일 손가락 팬/더블탭/핀치 줌을 제거했습니다.
  - 멀티터치 종료 및 전환 상황에서 드래그를 안정적으로 종료하도록 처리 로직을 개선했습니다.
  - 컨테이너 커서를 일관된 크로스헤어로 통일해 선택 UX를 명확히 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->