### PR TITLE
✨ feat: add Verc Analytics and enable external dev host

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { LanguageProvider } from "@/contexts/language-context";
 import { cookies } from "next/headers";
+import { Analytics } from "@vercel/analytics/next"
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -57,6 +58,7 @@ export default async function RootLayout({
         >
           <LanguageProvider>{children}</LanguageProvider>
         </ThemeProvider>
+        <Analytics />
       </body>
     </html>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.57.4",
         "@types/bcryptjs": "^2.4.6",
+        "@vercel/analytics": "^1.5.0",
         "autoprefixer": "^10.4.20",
         "bcryptjs": "^3.0.2",
         "canvas": "latest",
@@ -1932,6 +1933,44 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "next dev -H 0.0.0.0",
     "lint": "next lint",
     "start": "next start"
   },
@@ -40,6 +40,7 @@
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.57.4",
     "@types/bcryptjs": "^2.4.6",
+    "@vercel/analytics": "^1.5.0",
     "autoprefixer": "^10.4.20",
     "bcryptjs": "^3.0.2",
     "canvas": "latest",


### PR DESCRIPTION
- add @vercel/analyticsv1.5.0) to.json and package-lock
  to track-side analytics and support multiple frameworks via
  peer dependencies.
- import and mount <Analytics /> app/layout.tsx enable analytics
  collection across the application.
- change dev script to "next dev -H 0.00.0" so the dev server is
  reachable from external hosts (useful for testing on LAN or Docker).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음

- 유지 보수(Chores)
  - 애널리틱스 도구를 레이아웃에 통합하여 기본 사용 현황 수집을 활성화했습니다. 사용자 기능이나 동작에는 변화가 없습니다.
  - 개발 서버가 네트워크의 다른 기기에서도 접근 가능하도록 호스트 바인딩을 업데이트했습니다. 배포 환경에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->