### PR TITLE
✨ feat: shorten upload label and fix canvas coord scaling

### DIFF
--- a/components/signature-modal.tsx
+++ b/components/signature-modal.tsx
@@ -83,9 +83,13 @@ export default function SignatureModal({
       clientY = e.clientY;
     }
 
+    // Calculate the actual canvas coordinates considering the scale
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+
     return {
-      x: clientX - rect.left,
-      y: clientY - rect.top,
+      x: (clientX - rect.left) * scaleX,
+      y: (clientY - rect.top) * scaleY,
     };
   };
 

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -257,7 +257,7 @@ const translations: Record<Language, Record<string, string>> = {
     "dashboard.description": "총 {total}개의 문서를 관리하고 있습니다.",
     "dashboard.header.title": "내 문서",
     "dashboard.header.description": "문서를 관리하고 서명을 수집하세요",
-    "dashboard.upload": "문서 업로드",
+    "dashboard.upload": "업로드",
     "dashboard.empty.title": "아직 업로드된 문서가 없습니다",
     "dashboard.empty.description":
       "첫 번째 문서를 업로드하여 시작해보세요. 문서를 업로드하고 서명 영역을 지정한 후 다른 사람과 공유할 수 있습니다.",
@@ -560,7 +560,7 @@ const translations: Record<Language, Record<string, string>> = {
     "dashboard.header.title": "My Documents",
     "dashboard.header.description":
       "Manage your documents and collect signatures",
-    "dashboard.upload": "Upload Document",
+    "dashboard.upload": "Upload",
     "dashboard.empty.title": "No documents uploaded yet",
     "dashboard.empty.description":
       "Get started by uploading your first document. You can upload documents, define signature areas, and share them with others.",


### PR DESCRIPTION
- Change dashboard upload button text from "Upload Document" /
  "문서 업로드" to a shorter "Upload / "업로드" to improve UI
  consistency and prevent truncation in constrained layouts.
- Fix coordinate calculation in signature modal to account for the
  canvas-to-DOM scaling. Compute scaleX/scaleY from canvas.width/height
  and rect.width/height and multiply offsets so pointer positions map
  correctly to actual canvas pixel coordinates.

This prevents misplaced signature regions when the canvas is scaled
and tightens the upload label for better visual fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 서명 모달의 캔버스 좌표 계산을 보정하여 화면 크기/해상도/브라우저 줌과 무관하게 필기 위치가 정확히 반영되도록 개선했습니다. 마우스·터치 입력 시 선이 어긋나던 현상을 해소했습니다.
- 스타일
  - 대시보드 업로드 버튼 레이블을 간결하게 변경했습니다.
    - 한국어: ‘문서 업로드’ → ‘업로드’
    - 영어: ‘Upload Document’ → ‘Upload’

<!-- end of auto-generated comment: release notes by coderabbit.ai -->