### PR TITLE
✨ feat(sign simplify signature drawing and unused props

### DIFF
--- a/app/(sign)/sign/[id]/components/SignPage.tsx
+++ b/app/(sign)/sign/[id]/components/SignPage.tsx
@@ -265,10 +265,6 @@ export default function SignPageComponent({
         const actualWidth = pixelCoords.width * downscaleRatio;
         const actualHeight = pixelCoords.height * downscaleRatio;
 
-          actualX, actualY, actualWidth, actualHeight,
-          downscaleRatio,
-          canvasDimensions: { width: canvasWidth, height: canvasHeight }
-        });
 
         // Calculate the signature's aspect ratio
         const signatureAspectRatio = signatureImage.width / signatureImage.height;

--- a/components/signature-modal.tsx
+++ b/components/signature-modal.tsx
@@ -141,14 +141,10 @@ export default function SignatureModal({
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // Ensure the line width is set correctly for each stroke
-    ctx.lineWidth = PEN_WIDTH;
-
     const coords = getCoordinates(e.nativeEvent, canvas);
 
-    // Draw line from last position to current position
-    ctx.beginPath();
-    ctx.moveTo(lastX, lastY);
+    // Draw line from last position to current position without beginPath
+    // This creates a continuous line
     ctx.lineTo(coords.x, coords.y);
     ctx.stroke();
 


### PR DESCRIPTION
Remove passing of redundant positioning and canvas dimension props
  from SignPage. The code no longer forwards actualX/actualY,
  actualWidth/actualHeight, downscaleRatio, and canvasDimensions when
  preparing signature data, reducing prop clutter and preventing
  propagation of stale values.

- Simpl drawing logic in signature modal by removing explicit
  ctx.beginPath() and per-stroke ctx.lineWidth assignment. Drawing now
  uses a continuous path between last and current coordinates, giving
  smoother, uninterrupted ink and relying on a single lineWidth setup
  elsewhere.

- Keep calculation of signature aspect ratio intact to preserve
  scaling behavior.

These changes clean up the component interfaces and produce a more
natural, continuous signature rendering.