### PR TITLE
✨ feat(signature): add submit state and disable actions while sending

### DIFF
--- a/components/signature-modal.tsx
+++ b/components/signature-modal.tsx
@@ -33,6 +33,7 @@ export default function SignatureModal({
   const [hasSignature, setHasSignature] = useState(!!existingSignature);
   const [lastX, setLastX] = useState(0);
   const [lastY, setLastY] = useState(0);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const PEN_WIDTH = 5; // Increased from default
 
   // Initialize canvas when component mounts or when isOpen changes
@@ -171,11 +172,17 @@ export default function SignatureModal({
   };
 
   // Complete signature
-  const handleComplete = () => {
+  const handleComplete = async () => {
     if (!canvasRef.current || !hasSignature) return;
 
-    const signatureData = canvasRef.current.toDataURL("image/png");
-    onComplete(signatureData);
+    setIsSubmitting(true);
+
+    try {
+      const signatureData = canvasRef.current.toDataURL("image/png");
+      await onComplete(signatureData);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -206,17 +213,29 @@ export default function SignatureModal({
           {t("signature.instruction")}
         </p>
 
-        <DialogFooter className="flex justify-between sm:justify-between">
-          <Button type="button" variant="outline" onClick={clearCanvas}>
+        <DialogFooter className="flex justify-between sm:justify-between gap-6">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={clearCanvas}
+            disabled={isSubmitting}
+          >
             <Trash2 className="mr-2 h-4 w-4" />
             {t("signature.clear")}
           </Button>
           <Button
             type="button"
             onClick={handleComplete}
-            disabled={!hasSignature}
+            disabled={!hasSignature || isSubmitting}
           >
-            {t("signature.sign")}
+            {isSubmitting ? (
+              <>
+                <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                {t("signature.signing")}
+              </>
+            ) : (
+              t("signature.sign")
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -66,6 +66,7 @@ const translations: Record<Language, Record<string, string>> = {
     "signature.instruction": "위에 마우스나 손가락으로 서명을 그리세요",
     "signature.clear": "지우기",
     "signature.sign": "문서 서명",
+    "signature.signing": "서명 중...",
 
     // Language Selector
     "language.ko": "한국어",
@@ -365,6 +366,7 @@ const translations: Record<Language, Record<string, string>> = {
       "Draw your signature above using your mouse or finger",
     "signature.clear": "Clear",
     "signature.sign": "Sign Document",
+    "signature.signing": "Signing...",
 
     // Language Selector
     "language.ko": "한국어",


### PR DESCRIPTION
Introduce isSubmitting state to track async submission of the signature.
Make handleComplete async and set isSubmitting true while awaiting
onComplete so the UI reflects the in-flight operation and avoids double
submits. Disable the Clear button and the Sign button during submission,
and show a spinner with a "signing" label when submitting. Add a new
i18n key "signature.signing" in both Korean and English translations to
support the updated button text. Adjust footer spacing to accommodate the
spinner and improve layout.