### PR TITLE
✨ feat(sign prevent double-submit during generation

### DIFF
--- a/app/(sign)/sign/[id]/components/SignPage.tsx
+++ b/app/(sign)/sign/[id]/components/SignPage.tsx
@@ -56,6 +56,7 @@ export default function SignPageComponent({
   const [isGenerating, setIsGenerating] = useState<boolean>(false);
   const [generatingProgress, setGeneratingProgress] = useState<string>("");
   const [error, setError] = useState<string | null>(null);
+  const [isNavigating, setIsNavigating] = useState<boolean>(false);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [password, setPassword] = useState<string>("");
   const [isPasswordVerified, setIsPasswordVerified] = useState<boolean>(
@@ -338,6 +339,7 @@ export default function SignPageComponent({
       }
 
       // Navigate to completion page
+      setIsNavigating(true);
       router.push(`/sign/${documentData.id}/completed`);
     } catch (err) {
       console.error("Error generating signed document:", err);
@@ -346,7 +348,6 @@ export default function SignPageComponent({
           ? err.message
           : "Failed to generate signed document"
       );
-    } finally {
       setIsGenerating(false);
       setGeneratingProgress("");
     }
@@ -867,12 +868,12 @@ export default function SignPageComponent({
         <div className="flex justify-end gap-2">
           <Button
             onClick={handleGenerateDocument}
-            disabled={!allAreasSigned || isGenerating}
+            disabled={!allAreasSigned || isGenerating || isNavigating}
           >
-            {isGenerating ? (
+            {isGenerating || isNavigating ? (
               <>
                 <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
-                {generatingProgress || t("sign.generating")}
+                {isNavigating ? "페이지 이동 중..." : (generatingProgress || t("sign.generating"))}
               </>
             ) : (
               t("sign.saveDocument")


### PR DESCRIPTION
Add navigation guard signing flow to avoid duplicate requests and
confusing UI state when generating a signed document. Introduce
isNavigating state and set it before router.push to indicate that the
page is transitioning. Disable the Generate button also when navigation
is in progress and show a distinct label ("페이지 이동 중...") while
navigating. Ensure generating flags and progress are still reset on
completion.

This prevents racing/double submissions and provides clearer feedback
to users while the app navigates to the completion page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 문서 생성 완료 후 완료 페이지로 이동하는 동안 진행 상태를 표시하고, 로딩 메시지(“페이지 이동 중...”)를 노출합니다.
  - 이동 중에도 로딩 인디케이터가 유지되며, 생성 진행률 또는 이동 상태를 상황에 맞게 반영합니다.
- Bug Fixes
  - 이동 중 생성 버튼이 비활성화되어 중복 클릭을 방지합니다.
  - 로딩/진행 상태가 간헐적으로 잘못 표시되던 상황을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->