### PR TITLE
✨ feat: ProjectBreadcrumb component and integrate it

### DIFF
--- a/app/(document)/dashboard/page.tsx
+++ b/app/(document)/dashboard/page.tsx
@@ -1,10 +1,14 @@
 import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { DashboardHeader } from "@/components/dashboard/dashboard-header";
+import { ProjectBreadcrumb } from "@/components/breadcrumb";
 
 export default function DashboardPage() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-7xl mx-auto">
+        {/* Breadcrumb */}
+        <ProjectBreadcrumb />
+
         {/* Fixed Header - Server Component */}
         <DashboardHeader />
 

--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useLanguage } from "@/contexts/language-context";
+import { ProjectBreadcrumb } from "@/components/breadcrumb";
 import type {
   Document,
   Signature,
@@ -362,6 +363,9 @@ export default function DocumentDetailComponent({
   return (
     <div className="container mx-auto px-6 py-6 sm:px-4 sm:py-8">
       <div className="max-w-5xl mx-auto">
+        {/* Breadcrumb */}
+        <ProjectBreadcrumb />
+
         {/* Header */}
         <div className="mb-6 sm:mb-8"></div>
 

--- a/app/(document)/upload/components/UploadPage.tsx
+++ b/app/(document)/upload/components/UploadPage.tsx
@@ -2,6 +2,7 @@
 
 import DocumentUpload from "@/components/document-upload";
 import { useLanguage } from "@/contexts/language-context";
+import { ProjectBreadcrumb } from "@/components/breadcrumb";
 
 export default function UploadPageComponent() {
   const { t } = useLanguage();
@@ -9,7 +10,8 @@ export default function UploadPageComponent() {
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-5xl mx-auto">
-        <div className="mb-8"></div>
+        {/* Breadcrumb */}
+        <ProjectBreadcrumb />
 
         <div className="mb-8">
           <h1 className="text-3xl font-bold tracking-tight mb-2">

--- a/components/breadcrumb.tsx
+++ b/components/breadcrumb.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { useLanguage } from "@/contexts/language-context";
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export function ProjectBreadcrumb() {
+  const pathname = usePathname();
+  const { t } = useLanguage();
+
+  // Generate breadcrumb items based on current path
+  const getBreadcrumbItems = (): BreadcrumbItem[] => {
+    const items: BreadcrumbItem[] = [
+      {
+        label: t("breadcrumb.dashboard"),
+        href: "/dashboard",
+      },
+    ];
+
+    // Upload page
+    if (pathname === "/upload") {
+      items.push({
+        label: t("breadcrumb.upload"),
+      });
+    }
+
+    // Document details page
+    else if (pathname.startsWith("/document/")) {
+      items.push({
+        label: t("breadcrumb.details"),
+      });
+    }
+
+    return items;
+  };
+
+  const items = getBreadcrumbItems();
+
+  // Don't show breadcrumb on dashboard page (only one item)
+  if (items.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="mb-6">
+      <Breadcrumb>
+        <BreadcrumbList>
+          {items.map((item, index) => (
+            <div key={index} className="flex items-center">
+              <BreadcrumbItem>
+                {item.href ? (
+                  <BreadcrumbLink asChild>
+                    <Link href={item.href}>{item.label}</Link>
+                  </BreadcrumbLink>
+                ) : (
+                  <BreadcrumbPage>{item.label}</BreadcrumbPage>
+                )}
+              </BreadcrumbItem>
+              {index < items.length - 1 && <BreadcrumbSeparator />}
+            </div>
+          ))}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </div>
+  );
+}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -325,6 +325,11 @@ const translations: Record<Language, Record<string, string>> = {
     "resetPassword.successTitle": "비밀번호가 변경되었습니다",
     "resetPassword.successMessage":
       "새 비밀번호로 로그인해주세요. 잠시 후 로그인 페이지로 이동합니다.",
+
+    // Breadcrumb
+    "breadcrumb.dashboard": "대시보드",
+    "breadcrumb.upload": "문서 업로드",
+    "breadcrumb.details": "문서 상세",
   },
   en: {
     // Header
@@ -631,6 +636,11 @@ const translations: Record<Language, Record<string, string>> = {
     "resetPassword.successTitle": "Password Changed Successfully",
     "resetPassword.successMessage":
       "Please log in with your new password. You will be redirected to the login page shortly.",
+
+    // Breadcrumb
+    "breadcrumb.dashboard": "Dashboard",
+    "breadcrumb.upload": "Upload Document",
+    "breadcrumb.details": "Document Details",
   },
 };
 


### PR DESCRIPTION
Add a new client-side ProjectBreadcrumb component to render localized
breadcrumb navigation based on the current pathname. Integrate the
breadcrumb into Dashboard, Upload and Document Detail pages so users
can see contextual navigation across upload and document details.

Also add localization keys for breadcrumb labels in Korean and English
language contexts. Keep the breadcrumb hidden on the dashboard when
only a single item is present to avoid redundancy.

This improves UX by providing consistent, localised navigation cues
and centralises breadcrumb logic in a reusable component.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #54 
- <kbd>&nbsp;1&nbsp;</kbd> #53 👈 
<!-- GitButler Footer Boundary Bottom -->

