### PR TITLE
✨ i18n: extract document action and tweak UI

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -398,7 +398,7 @@ export default function DocumentDetailComponent({
                           className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
                         >
                           <Edit className="mr-1 h-3 w-3" />
-                          수정
+                          {t("document.actions.edit")}
                         </Button>
                         <Button
                           variant="destructive"
@@ -407,7 +407,7 @@ export default function DocumentDetailComponent({
                           className="h-9 px-3 text-sm font-medium"
                         >
                           <Trash2 className="mr-1 h-3 w-3" />
-                          삭제
+                          {t("document.actions.delete")}
                         </Button>
                       </div>
                       {/* Right Group - Publish */}
@@ -418,7 +418,7 @@ export default function DocumentDetailComponent({
                           className="h-9 px-3 text-sm font-medium bg-blue-600 hover:bg-blue-700"
                         >
                           <Share className="mr-1 h-3 w-3" />
-                          발급
+                          {t("document.actions.publish")}
                         </Button>
                       )}
                     </div>
@@ -491,7 +491,7 @@ export default function DocumentDetailComponent({
                           className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
                         >
                           <Edit className="mr-2 h-4 w-4" />
-                          수정
+                          {t("document.actions.edit")}
                         </Button>
                         <Button
                           variant="destructive"
@@ -500,7 +500,7 @@ export default function DocumentDetailComponent({
                           className="h-10 px-4 text-sm font-medium"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />
-                          삭제
+                          {t("document.actions.delete")}
                         </Button>
                       </div>
                       {/* Right Group - Publish */}
@@ -511,7 +511,7 @@ export default function DocumentDetailComponent({
                           className="h-10 px-4 text-sm font-medium bg-blue-600 hover:bg-blue-700"
                         >
                           <Share className="mr-2 h-4 w-4" />
-                          발급
+                          {t("document.actions.publish")}
                         </Button>
                       )}
                     </div>

--- a/components/language-selector.tsx
+++ b/components/language-selector.tsx
@@ -31,7 +31,7 @@ export default function LanguageSelector() {
           className="gap-2 border-primary/20 hover:bg-primary/5"
         >
           <Globe className="h-4 w-4" />
-          <span>{language.toUpperCase()}</span>
+          <span className="text-xs">{language.toUpperCase()}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -330,6 +330,11 @@ const translations: Record<Language, Record<string, string>> = {
     "breadcrumb.dashboard": "대시보드",
     "breadcrumb.upload": "문서 업로드",
     "breadcrumb.details": "문서 상세",
+
+    // Document Actions
+    "document.actions.edit": "수정",
+    "document.actions.delete": "삭제",
+    "document.actions.publish": "발급",
   },
   en: {
     // Header
@@ -641,6 +646,11 @@ const translations: Record<Language, Record<string, string>> = {
     "breadcrumb.dashboard": "Dashboard",
     "breadcrumb.upload": "Upload Document",
     "breadcrumb.details": "Document Details",
+
+    // Document Actions
+    "document.actions.edit": "Edit",
+    "document.actions.delete": "Delete",
+    "document.actions.publish": "Publish",
   },
 };
 


### PR DESCRIPTION
- Replace hard Korean labels ("수정", "삭제", "발급") in DocumentDetailPage
  with translation keys (t("document.actions.edit"), t("document.actions.delete"),
  t("document.actions.publish")) to enable localization and reuse across locales.
- Add corresponding translation entries for Korean (ko) and English (en) in the
  language context to provide the new keys.
- Adjust language selector button styling by setting the language text to
  text-xs to better match UI proportions.

This change centralizes UI text for document actions, prepares the app for
multi-language support, and fixes a visual sizing inconsistency in the language
selector.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #54 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #53 
<!-- GitButler Footer Boundary Bottom -->

