### PR TITLE
✨ feat(document): scroll position after selection

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -120,6 +120,14 @@ export default function DocumentDetailComponent({
     // Store the area coordinates as relative percentages (same as DocumentUpload)
     setSignatureAreas([...signatureAreas, area]);
     setIsSelecting(false);
+
+    // Restore scroll position after state updates
+    requestAnimationFrame(() => {
+      if (documentContainerRef.current) {
+        documentContainerRef.current.scrollTop = scrollPosition.top;
+        documentContainerRef.current.scrollLeft = scrollPosition.left;
+      }
+    });
   };
 
   const handleRemoveArea = (index: number) => {
@@ -361,6 +369,19 @@ export default function DocumentDetailComponent({
   const handleZoomReset = () => {
     setZoomLevel(1);
   };
+
+  // Restore scroll position when exiting selection mode
+  useEffect(() => {
+    if (!isEditMode && documentContainerRef.current && (scrollPosition.top !== 0 || scrollPosition.left !== 0)) {
+      // Use setTimeout to ensure DOM has updated
+      setTimeout(() => {
+        if (documentContainerRef.current) {
+          documentContainerRef.current.scrollTop = scrollPosition.top;
+          documentContainerRef.current.scrollLeft = scrollPosition.left;
+        }
+      }, 0);
+    }
+  }, [isEditMode, scrollPosition]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     // Allow dragging when zoomed or when content overflows container

--- a/components/area-selector.tsx
+++ b/components/area-selector.tsx
@@ -3,8 +3,6 @@
 import type React from "react";
 
 import { useState, useRef, useEffect } from "react";
-import { ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
-import { Button } from "@/components/ui/button";
 
 // Import the useLanguage hook at the top of the file
 import { useLanguage } from "@/contexts/language-context";
@@ -102,20 +100,6 @@ export default function AreaSelector({
       console.warn('Failed to get image container dimensions:', error);
       return { x: 0, y: 0 };
     }
-  };
-
-  const handleZoomIn = () => {
-    const newZoom = Math.min(zoomLevel + 0.25, 3);
-    onZoomChange?.(newZoom);
-  };
-
-  const handleZoomOut = () => {
-    const newZoom = Math.max(zoomLevel - 0.25, 0.5);
-    onZoomChange?.(newZoom);
-  };
-
-  const handleZoomReset = () => {
-    onZoomChange?.(1);
   };
 
   const handleContainerMouseDown = (e: React.MouseEvent) => {
@@ -365,39 +349,6 @@ export default function AreaSelector({
 
   return (
     <div className="relative">
-      {/* Zoom Controls */}
-      <div className="absolute top-2 sm:top-4 right-2 sm:right-4 z-10 flex flex-col gap-1 sm:gap-2 bg-white/90 backdrop-blur-sm rounded-lg p-1 sm:p-2 shadow-lg">
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={handleZoomIn}
-          disabled={zoomLevel >= 3}
-          className="p-1 sm:p-2 h-6 w-6 sm:h-8 sm:w-8"
-        >
-          <ZoomIn className="h-3 w-3 sm:h-4 sm:w-4" />
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={handleZoomOut}
-          disabled={zoomLevel <= 0.5}
-          className="p-1 sm:p-2 h-6 w-6 sm:h-8 sm:w-8"
-        >
-          <ZoomOut className="h-3 w-3 sm:h-4 sm:w-4" />
-        </Button>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={handleZoomReset}
-          disabled={zoomLevel === 1}
-          className="p-1 sm:p-2 h-6 w-6 sm:h-8 sm:w-8"
-        >
-          <RotateCcw className="h-3 w-3 sm:h-4 sm:w-4" />
-        </Button>
-        <div className="text-xs text-center font-medium px-1 py-0.5 bg-gray-100 rounded">
-          {Math.round(zoomLevel * 100)}%
-        </div>
-      </div>
       <div
         ref={containerRef}
         className="relative overflow-auto max-h-[50vh] sm:max-h-[70vh]"

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react";
 
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Upload, FileImage, Trash2, ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -74,6 +74,14 @@ export default function DocumentUpload() {
     // Store the area coordinates as relative percentages
     setSignatureAreas([...signatureAreas, area]);
     setIsSelecting(false);
+
+    // Restore scroll position after state updates
+    requestAnimationFrame(() => {
+      if (documentContainerRef.current) {
+        documentContainerRef.current.scrollTop = scrollPosition.top;
+        documentContainerRef.current.scrollLeft = scrollPosition.left;
+      }
+    });
   };
 
   const handleRemoveArea = (index: number) => {
@@ -102,6 +110,19 @@ export default function DocumentUpload() {
   const handleZoomReset = () => {
     setZoomLevel(1);
   };
+
+  // Restore scroll position when exiting selection mode
+  useEffect(() => {
+    if (!isSelecting && documentContainerRef.current && (scrollPosition.top !== 0 || scrollPosition.left !== 0)) {
+      // Use setTimeout to ensure DOM has updated
+      setTimeout(() => {
+        if (documentContainerRef.current) {
+          documentContainerRef.current.scrollTop = scrollPosition.top;
+          documentContainerRef.current.scrollLeft = scrollPosition.left;
+        }
+      }, 0);
+    }
+  }, [isSelecting, scrollPosition]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     // Allow dragging when zoomed or when content overflows container


### PR DESCRIPTION
- Add useEffect import and restore logic in document-upload to reset
  the container's scrollTop/scrollLeft after exiting selection mode and
  immediately after adding an area. This prevents the view from jumping
  when toggling selection or updating signature areas.
- Mirror the same requestAnimationFrame and setTimeout-based scroll
  restoration in DocumentDetailPage so the detail view behaves
  consistently when adding/removing signature areas or leaving edit
  mode.
- Remove duplicated zoom controls and related handlers from
  area-selector: eliminate unused Zoom/Rotate imports, Button usage and
  zoom in/out/reset handlers and UI, since zoom is now controlled at a
  different level.

Why: fix UX issues where the document viewport would lose its scroll
position during area selection/edit operations and remove redundant
zoom UI to simplify the area selector component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 서명 영역 추가·선택 후 문서 뷰어의 스크롤 위치가 이전 상태로 안정적으로 복원되도록 개선했습니다. 선택 모드 종료 시에도 저장된 스크롤 위치를 복원합니다.

* **Refactor**
  * 영역 선택기에서 내장된 확대/축소 UI와 관련 로직을 제거하고, 외부에서 전달되는 줌 상태만 반영하도록 단순화했습니다. 기존 드래그 이동 및 영역 렌더링 동작은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->