### PR TITLE
✨ feat: replace scroll state with ref and reorganize controls

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -58,10 +58,7 @@ export default function DocumentDetailComponent({
   const [isPublishModalOpen, setIsPublishModalOpen] = useState<boolean>(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState<boolean>(false);
   const documentContainerRef = useRef<HTMLDivElement>(null);
-  const [scrollPosition, setScrollPosition] = useState<{
-    top: number;
-    left: number;
-  }>({ top: 0, left: 0 });
+  const scrollPositionRef = useRef<{ top: number; left: number }>({ top: 0, left: 0 });
   const [signedDocumentUrl, setSignedDocumentUrl] = useState<string | null>(null);
   const [documentUrl, setDocumentUrl] = useState<string | null>(null);
   const [zoomLevel, setZoomLevel] = useState<number>(1);
@@ -105,13 +102,10 @@ export default function DocumentDetailComponent({
   const handleAddSignatureArea = () => {
     // Save current scroll position before switching to selection mode
     if (documentContainerRef.current) {
-      const scrollTop = documentContainerRef.current.scrollTop;
-      const scrollLeft = documentContainerRef.current.scrollLeft;
-
-      setScrollPosition({
-        top: scrollTop,
-        left: scrollLeft,
-      });
+      scrollPositionRef.current = {
+        top: documentContainerRef.current.scrollTop,
+        left: documentContainerRef.current.scrollLeft,
+      };
     }
     setIsSelecting(true);
   };
@@ -124,8 +118,8 @@ export default function DocumentDetailComponent({
     // Restore scroll position after state updates
     requestAnimationFrame(() => {
       if (documentContainerRef.current) {
-        documentContainerRef.current.scrollTop = scrollPosition.top;
-        documentContainerRef.current.scrollLeft = scrollPosition.left;
+        documentContainerRef.current.scrollTop = scrollPositionRef.current.top;
+        documentContainerRef.current.scrollLeft = scrollPositionRef.current.left;
       }
     });
   };
@@ -370,18 +364,6 @@ export default function DocumentDetailComponent({
     setZoomLevel(1);
   };
 
-  // Restore scroll position when exiting selection mode
-  useEffect(() => {
-    if (!isEditMode && documentContainerRef.current && (scrollPosition.top !== 0 || scrollPosition.left !== 0)) {
-      // Use setTimeout to ensure DOM has updated
-      setTimeout(() => {
-        if (documentContainerRef.current) {
-          documentContainerRef.current.scrollTop = scrollPosition.top;
-          documentContainerRef.current.scrollLeft = scrollPosition.left;
-        }
-      }, 0);
-    }
-  }, [isEditMode, scrollPosition]);
 
   const handleMouseDown = (e: React.MouseEvent) => {
     // Allow dragging when zoomed or when content overflows container
@@ -755,7 +737,7 @@ export default function DocumentDetailComponent({
               onAreaSelected={handleAreaSelected}
               onCancel={() => setIsSelecting(false)}
               existingAreas={signatureAreas}
-              initialScrollPosition={scrollPosition}
+              initialScrollPosition={scrollPositionRef.current}
               zoomLevel={zoomLevel}
               onZoomChange={setZoomLevel}
             />


### PR DESCRIPTION
Replace the scroll position useState with a useRef to avoid redundant re-renders
and simplify scroll save/restore logic when entering/exiting signature selection.
Update code to read/write scroll position via scrollPositionRef in handlers and
pass the current ref value to the SignatureSelection component.

Reorganize the document action controls: group Add/Clear buttons, promote Save
button, and move the file title below the button group for clearer layout and
better UX. Remove duplicated/unused cleanup effect and old button group to keep
the component leaner and avoid stale state updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 선택된 문서 화면에 인라인 버튼 그룹 추가: 서명 영역 추가, 지우기, 저장.
  - 영역 선택 흐름에서 현재 스크롤 위치를 유지/복원하여 작업 연속성 개선.
- 스타일
  - 파일명 표시 위치를 버튼 그룹 아래로 이동.
  - 제목 행과 영역 선택기 레이아웃 조정으로 화면 구성 정돈.
- 리팩터
  - 스クロール 위치 관리 방식을 개선하여 영역 선택 전후 스크롤 복원이 더 매끄럽고 일관되게 동작.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->