### PR TITLE
✨ feat: load and render subscription plans from backend

### DIFF
--- a/app/actions/subscription-actions.ts
+++ b/app/actions/subscription-actions.ts
@@ -427,7 +427,7 @@ export async function getSubscriptionPlans(): Promise<{
       .from("subscription_plans")
       .select("*")
       .eq("is_active", true)
-      .order("price_cents", { ascending: true });
+      .order("order", { ascending: true });
 
     if (error) {
       console.error("Get subscription plans error:", error);


### PR DESCRIPTION
- Add getSubscriptionPlans integration to HomePage: fetch plans on mount
  and store them in local state to drive pricing UI.
- Replace hardcoded pricing array with dynamic pricingPlans mapped from
  fetched data. Build planKey, detect pro/enterprise, and format price
  and monthly document limit features accordingly.
- Add formatPrice helper to display free/enterprise labels and numeric
  prices consistently.
- Reorder import lines, add Card/CardContent, cn utility, and adjust
  React import order for consistency.
- Fix CSS class indentation for angled card variant.
- Change subscription query ordering from price_cents to order on the
  backend action to control plan sequence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 가격 플랜을 백엔드에서 동적으로 로드·표시하여 최신 요금제와 기능을 자동 반영
  - 월 문서 제한을 무제한/수치에 따라 자동 표기
  - 플랜 유형에 따라 인기 배지와 카드 레이아웃이 동적으로 조정
- Style
  - 가격 섹션 텍스트와 배지 배치 등 레이아웃 미세 조정
- Chores
  - 활성 요금제 정렬 기준을 가격 중심에서 표시 순서 기반으로 변경하여 노출 순서 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->