### PR TITLE
✨ feat(auth add OAuth callback and Kakao sign-in flow

### DIFF
--- a/app/(auth)/auth/callback/route.ts
+++ b/app/(auth)/auth/callback/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+// The client you created from the Server-Side Auth instructions
+import { createServerSupabase } from "@/lib/supabase/server";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  // if "next" is in param, use it as the redirect URL
+  let next = searchParams.get("next") ?? "/";
+  if (!next.startsWith("/")) {
+    // if "next" is not a relative URL, use the default
+    next = "/";
+  }
+
+  if (code) {
+    const supabase = await createServerSupabase();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
+      const isLocalEnv = process.env.NODE_ENV === "development";
+      if (isLocalEnv) {
+        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
+        return NextResponse.redirect(`${origin}${next}`);
+      } else if (forwardedHost) {
+        return NextResponse.redirect(`https://${forwardedHost}${next}`);
+      } else {
+        return NextResponse.redirect(`${origin}${next}`);
+      }
+    }
+  }
+
+  // return the user to an error page with instructions
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`);
+}

--- a/app/(auth)/forgot-password/actions.ts
+++ b/app/(auth)/forgot-password/actions.ts
@@ -27,7 +27,11 @@ export async function forgotPassword(prevState: any, formData: FormData) {
 
     // Send password reset email
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3001'}/auth/confirm?next=${encodeURIComponent('/reset-password')}`,
+      redirectTo: `${
+        process.env.NEXT_PUBLIC_SITE_URL
+          ? process.env.NEXT_PUBLIC_SITE_URL
+          : "http://localhost:3000"
+      }/auth/confirm?next=${encodeURIComponent("/reset-password")}`,
     });
 
     if (error) {

--- a/app/(auth)/login/LoginPage.tsx
+++ b/app/(auth)/login/LoginPage.tsx
@@ -1,22 +1,19 @@
 "use client";
 
-import type React from "react";
-
-import Link from "next/link";
-import { FileSignature, Github, KeyRound, Mail } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
-import { useLanguage } from "@/contexts/language-context";
-import { login } from "./actions";
-import { useFormState, useFormStatus } from "react-dom";
 import { SubmitButton } from "@/components/ui/submit-button";
+import { useLanguage } from "@/contexts/language-context";
+import { FileSignature, Github, KeyRound, Mail } from "lucide-react";
+import Link from "next/link";
+import { useFormState } from "react-dom";
+import { login, signInWithKakao } from "./actions";
 
 export default function LoginPage() {
   const { t } = useLanguage();
 
-  const { pending } = useFormStatus();
   const [state, dispatch] = useFormState(login, null);
 
   return (
@@ -155,21 +152,23 @@ export default function LoginPage() {
                 <Github className="mr-2 h-4 w-4" />
                 Github
               </Button>
-              <Button variant="outline" type="button" className="w-full">
-                <svg
-                  className="mr-2 h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <rect width="24" height="24" rx="12" fill="#FEE500" />
-                  <path
-                    d="M12 5.5C8.41 5.5 5.5 7.865 5.5 10.8C5.5 12.7 6.62 14.3875 8.32 15.3375C8.15 15.9125 7.64 17.8 7.59 18.0375C7.53 18.35 7.75 18.35 7.89 18.25C8 18.175 10.21 16.6625 10.83 16.2375C11.21 16.3 11.6 16.325 12 16.325C15.59 16.325 18.5 13.96 18.5 11.025C18.5 8.09 15.59 5.5 12 5.5Z"
-                    fill="#392020"
-                  />
-                </svg>
-                {t("login.kakaoTalk")}
-              </Button>
+              <form action={signInWithKakao} className="w-full">
+                <Button variant="outline" type="submit" className="w-full">
+                  <svg
+                    className="mr-2 h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect width="24" height="24" rx="12" fill="#FEE500" />
+                    <path
+                      d="M12 5.5C8.41 5.5 5.5 7.865 5.5 10.8C5.5 12.7 6.62 14.3875 8.32 15.3375C8.15 15.9125 7.64 17.8 7.59 18.0375C7.53 18.35 7.75 18.35 7.89 18.25C8 18.175 10.21 16.6625 10.83 16.2375C11.21 16.3 11.6 16.325 12 16.325C15.59 16.325 18.5 13.96 18.5 11.025C18.5 8.09 15.59 5.5 12 5.5Z"
+                      fill="#392020"
+                    />
+                  </svg>
+                  {t("login.kakaoTalk")}
+                </Button>
+              </form>
             </div>
 
             <div className="text-center text-sm">

--- a/app/(auth)/login/actions.ts
+++ b/app/(auth)/login/actions.ts
@@ -50,3 +50,15 @@ export async function login(_: any, formData: FormData) {
   revalidatePath("/", "layout");
   redirect("/dashboard");
 }
+
+export async function signInWithKakao() {
+  const supabase = await createServerSupabase();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: "kakao",
+    options: {
+      redirectTo: process.env.NEXT_PUBLIC_SITE_URL
+        ? `https://${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`
+        : "http://localhost:3000/auth/callback",
+    },
+  });
+}


### PR DESCRIPTION
- Add server-side /authallback route to exchange OAuth code for a Supabase session and redirect users back to the app
  - reads "code" and optional "next" query param, validates "next" as a relative path
  - exchanges code for session via server Supabase helper
  - supports dev, load-balanced (X-Forwarded-Host), and origin fallback redirect handling
  - redirects to a user-facing error page on exchange failure
- Implement Kakao sign-in flow
  - add signInWithKakao action initiating OAuth sign-in with redirectTo pointing to /auth/callback (or localhost in dev)
  - wire into LoginPage by replacing static Kakao button with a form that submits to signInWithKakao while preserving UI and localization
- Miscellaneous cleanup
  - reorder/clean imports in LoginPage and remove unused form status call
  - ensure login flow revalidation/redirect behavior remains intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 로그인 지원을 추가하고, 버튼 클릭 대신 폼 제출 흐름으로 연결해 일관된 소셜 로그인 경험을 제공합니다.
  - 인증 콜백 처리를 도입해 로그인/회원가입 후 환경에 맞는 안전한 리다이렉트를 수행하며, 실패 시 전용 오류 페이지로 안내합니다.
- 버그 수정
  - 비밀번호 재설정 이메일의 리다이렉트 URL이 환경 변수 기반 도메인(NEXT_PUBLIC_SITE_URL)으로 생성되며, 기본값을 http://localhost:3000으로 정정해 잘못된 호스트로 이동하던 문제를 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->