### PR TITLE
✨ feat(auth): add Kakao OAuth button component and use it

### DIFF
--- a/app/(auth)/login/LoginPage.tsx
+++ b/app/(auth)/login/LoginPage.tsx
@@ -9,7 +9,8 @@ import { useLanguage } from "@/contexts/language-context";
 import { FileSignature, Github, KeyRound, Mail } from "lucide-react";
 import Link from "next/link";
 import { useFormState } from "react-dom";
-import { login, signInWithKakao } from "./actions";
+import { login } from "./actions";
+import KakaoLoginButton from "./components/kakao-login-button";
 
 export default function LoginPage() {
   const { t } = useLanguage();
@@ -152,23 +153,7 @@ export default function LoginPage() {
                 <Github className="mr-2 h-4 w-4" />
                 Github
               </Button>
-              <form action={signInWithKakao} className="w-full">
-                <Button variant="outline" type="submit" className="w-full">
-                  <svg
-                    className="mr-2 h-4 w-4"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <rect width="24" height="24" rx="12" fill="#FEE500" />
-                    <path
-                      d="M12 5.5C8.41 5.5 5.5 7.865 5.5 10.8C5.5 12.7 6.62 14.3875 8.32 15.3375C8.15 15.9125 7.64 17.8 7.59 18.0375C7.53 18.35 7.75 18.35 7.89 18.25C8 18.175 10.21 16.6625 10.83 16.2375C11.21 16.3 11.6 16.325 12 16.325C15.59 16.325 18.5 13.96 18.5 11.025C18.5 8.09 15.59 5.5 12 5.5Z"
-                      fill="#392020"
-                    />
-                  </svg>
-                  {t("login.kakaoTalk")}
-                </Button>
-              </form>
+              <KakaoLoginButton />
             </div>
 
             <div className="text-center text-sm">

--- a/app/(auth)/login/actions.ts
+++ b/app/(auth)/login/actions.ts
@@ -50,15 +50,3 @@ export async function login(_: any, formData: FormData) {
   revalidatePath("/", "layout");
   redirect("/dashboard");
 }
-
-export async function signInWithKakao() {
-  const supabase = await createServerSupabase();
-  const { data, error } = await supabase.auth.signInWithOAuth({
-    provider: "kakao",
-    options: {
-      redirectTo: process.env.NEXT_PUBLIC_SITE_URL
-        ? `https://${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`
-        : "http://localhost:3000/auth/callback",
-    },
-  });
-}

--- a/app/(auth)/login/components/kakao-login-button.tsx
+++ b/app/(auth)/login/components/kakao-login-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/language-context";
+import { createClientSupabase } from "@/lib/supabase/client";
+
+export default function KakaoLoginButton() {
+  const { t } = useLanguage();
+
+  const signInWithKakao = async () => {
+    const supabase = createClientSupabase();
+    await supabase.auth.signInWithOAuth({
+      provider: "kakao",
+      options: {
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      type="button"
+      className="w-full"
+      onClick={signInWithKakao}
+    >
+      <svg
+        className="mr-2 h-4 w-4"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="24" height="24" rx="12" fill="#FEE500" />
+        <path
+          d="M12 5.5C8.41 5.5 5.5 7.865 5.5 10.8C5.5 12.7 6.62 14.3875 8.32 15.3375C8.15 15.9125 7.64 17.8 7.59 18.0375C7.53 18.35 7.75 18.35 7.89 18.25C8 18.175 10.21 16.6625 10.83 16.2375C11.21 16.3 11.6 16.325 12 16.325C15.59 16.325 18.5 13.96 18.5 11.025C18.5 8.09 15.59 5.5 12 5.5Z"
+          fill="#392020"
+        />
+      </svg>
+      {t("login.kakaoTalk")}
+    </Button>
+  );
+}


### PR DESCRIPTION
Extract Kakao login UI into a client-side component and replace the
previous server action form. This adds a new
app/(auth)/login/components/kakao-login-button.tsx component that
handles initiating Supabase OAuth sign-in for the kakao provider from
the client, uses the language context for label text, and renders the
Kakao icon inside a styled Button.

Update LoginPage to import and render the new KakaoLoginButton instead
of the removed signInWithKakao form/button. Remove the server-side
signInWithKakao action from actions.ts since OAuth is initiated from the
client now. This simplifies the auth flow, avoids a redundant server
action, and keeps the redirect URL logic centralized on the client-side
Supabase client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카카오 로그인 버튼을 추가해 아이콘과 현지화된 라벨로 더 명확한 진입점을 제공합니다.
  - 환경변수 기반의 리다이렉트 URL 처리를 통해 로그인 후 이동을 안정화했습니다.
- 리팩터링
  - 로그인 페이지의 카카오 로그인 영역을 전용 버튼 컴포넌트로 통합해 UI를 단순화했습니다.
  - 기존 폼 제출 흐름을 버튼 클릭 기반의 직접 로그인 트리거로 전환하여 상호작용을 일관되게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->