### PR TITLE
✨ feat(auth): add GitHub OAuth button and dev script

### DIFF
--- a/app/(auth)/login/LoginPage.tsx
+++ b/app/(auth)/login/LoginPage.tsx
@@ -6,11 +6,12 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { SubmitButton } from "@/components/ui/submit-button";
 import { useLanguage } from "@/contexts/language-context";
-import { FileSignature, Github, KeyRound, Mail } from "lucide-react";
+import { FileSignature, KeyRound, Mail } from "lucide-react";
 import Link from "next/link";
 import { useFormState } from "react-dom";
 import { login } from "./actions";
 import KakaoLoginButton from "./components/kakao-login-button";
+import GithubLoginButton from "./components/github-login-button";
 
 export default function LoginPage() {
   const { t } = useLanguage();
@@ -149,10 +150,7 @@ export default function LoginPage() {
                 </svg>
                 Google
               </Button>
-              <Button variant="outline" type="button" className="w-full">
-                <Github className="mr-2 h-4 w-4" />
-                Github
-              </Button>
+              <GithubLoginButton />
               <KakaoLoginButton />
             </div>
 

--- a/app/(auth)/login/components/github-login-button.tsx
+++ b/app/(auth)/login/components/github-login-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/language-context";
+import { createClientSupabase } from "@/lib/supabase/client";
+import { Github } from "lucide-react";
+
+export default function GithubLoginButton() {
+  const { t } = useLanguage();
+
+  const signInWithGithub = async () => {
+    const supabase = createClientSupabase();
+    await supabase.auth.signInWithOAuth({
+      provider: "github",
+      options: {
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      type="button"
+      className="w-full"
+      onClick={signInWithGithub}
+    >
+      <Github className="mr-2 h-4 w-4" />
+      Github
+    </Button>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
-    "dev": "next dev -H 0.0.0.0",
+    "dev": "next dev",
     "lint": "next lint",
     "start": "next start"
   },


### PR DESCRIPTION
Add a reusable GitHub login component that triggers Supabase
OAuth sign-in and redirects to the site's auth callback. Wire the new
GithubLoginButton into the login page replacing the previous static
button so social auth flows are handled consistently.

Also remove the custom host flag from the dev script in package.json
("next dev -H 0.0.0.0" → "next dev") to restore the default Next.js dev
behavior and simplify local startup.

Why:
- Provide a dedicated client component to encapsulate GitHub OAuth logic
  and use the shared Supabase client for authentication.
- Improve maintainability by centralizing OAuth behavior and UI.
- Remove an unnecessary development flag that may cause unexpected
  binding behavior across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 로그인 화면의 GitHub 로그인 옵션을 전용 버튼으로 교체하여 UI 일관성과 사용성을 개선했습니다.
  - 다른 로그인·폼 동작에는 변화 없이, 제공자 선택 UI만 정리되었습니다.

- Chores
  - 개발 서버 실행 설정을 단순화하여 로컬 개발 환경 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->