### PR TITLE
✨ feat(auth): add Google OAuth login button component

### DIFF
--- a/app/(auth)/login/LoginPage.tsx
+++ b/app/(auth)/login/LoginPage.tsx
@@ -12,6 +12,7 @@ import { useFormState } from "react-dom";
 import { login } from "./actions";
 import KakaoLoginButton from "./components/kakao-login-button";
 import GithubLoginButton from "./components/github-login-button";
+import GoogleLoginButton from "./components/google-login-button";
 
 export default function LoginPage() {
   const { t } = useLanguage();
@@ -125,31 +126,7 @@ export default function LoginPage() {
             </div>
 
             <div className="grid grid-cols-3 gap-4">
-              <Button variant="outline" type="button" className="w-full">
-                <svg
-                  className="mr-2 h-4 w-4"
-                  viewBox="0 0 24 24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                    fill="#4285F4"
-                  />
-                  <path
-                    d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                    fill="#34A853"
-                  />
-                  <path
-                    d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                    fill="#FBBC05"
-                  />
-                  <path
-                    d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                    fill="#EA4335"
-                  />
-                </svg>
-                Google
-              </Button>
+              <GoogleLoginButton />
               <GithubLoginButton />
               <KakaoLoginButton />
             </div>

--- a/app/(auth)/login/components/google-login-button.tsx
+++ b/app/(auth)/login/components/google-login-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/language-context";
+import { createClientSupabase } from "@/lib/supabase/client";
+
+export default function GoogleLoginButton() {
+  const { t } = useLanguage();
+
+  const signInWithGoogle = async () => {
+    const supabase = createClientSupabase();
+    await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
+      },
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      type="button"
+      className="w-full"
+      onClick={signInWithGoogle}
+    >
+      <svg
+        className="mr-2 h-4 w-4"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+          fill="#4285F4"
+        />
+        <path
+          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+          fill="#34A853"
+        />
+        <path
+          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+          fill="#FBBC05"
+        />
+        <path
+          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+          fill="#EA4335"
+        />
+      </svg>
+      Google
+    </Button>
+  );
+}


### PR DESCRIPTION
Add a reusable GoogleLoginButton component and integrate it into the
login page. The new component encapsulates the Google OAuth flow
trigger using the Supabase client and renders the Google SVG inside
the shared UI Button.

Why:
- Extracts the previous inline Google button markup into a dedicated
  client component for clarity and reuse.
- Centralizes signInWithGoogle logic to ensure consistent redirect
  handling via NEXT_PUBLIC_SITE_URL and to prepare for further
  platform-specific adjustments.
- Cleans up LoginPage by replacing the inline SVG/button with the
  GoogleLoginButton component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 소셜 로그인 영역의 Google 버튼을 전용 컴포넌트로 교체했습니다. 기능과 동작 흐름은 동일하며, 코드 재사용성과 유지보수가 향상되었습니다.
- Style
  - 버튼을 전체폭 아웃라인 스타일과 아이콘+레이블 구성으로 통일해 시각적 일관성과 브랜드 일치성을 높였습니다.
- User Experience
  - 클릭 영역과 라벨 표기를 명확히 하여 접근성과 사용성을 소폭 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->