### PR TITLE
✨ chore(i18n): update Terms of Service branding to SeukSeuk

### DIFF
--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -1092,9 +1092,9 @@ const translations: Record<Language, Record<string, string>> = {
 
     // Terms of Service Page
     "term.backToHome": "Back to Home",
-    "term.title": "www.seuk-seuk.com Terms of Service",
+    "term.title": "SeukSeuk Terms of Service",
     "term.intro":
-      'These Terms of Service establish the rights, obligations, responsibilities, and other necessary matters between the operator and members regarding the use of the electronic document signing and management services provided by an individual (hereinafter referred to as the "Operator") through www.seuk-seuk.com (hereinafter referred to as the "Service").',
+      'These Terms of Service establish the rights, obligations, responsibilities, and other necessary matters between the operator and members regarding the use of the electronic document signing and management services provided by an individual (hereinafter referred to as the "Operator") through SeukSeuk (hereinafter referred to as the "Service").',
 
     // Chapter 1
     "term.chapter1.title": "Chapter 1: General Provisions",


### PR DESCRIPTION
- Replace occurrences of "www.seuk-seuk.com" with the product name
  "SeukSeuk" in Terms of Service strings.
- Update the page title and intro copy so the service is referenced by
  its brand name rather than a full URL.

Reason:
- Improve consistency and polish in user-facing language by using the
  brand name everywhere, avoiding hard-coded URLs in localized text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 영어 서비스 약관 문구를 최신 브랜드 표기(“www.seuk-seuk.com” → “SeukSeuk”)로 업데이트했습니다.
  * 영어 약관 서문 표현을 다듬어 브랜드 호칭과 문장 흐름을 개선했습니다.
  * 한국어 번역 및 기능 동작에는 변경이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->