### PR TITLE
✨ feat: generate signed URL using service role

### DIFF
--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -537,6 +537,8 @@ export async function getDocumentSignedUrl(
   error?: string;
 }> {
   try {
+    // Use service role to bypass RLS for signed URL generation
+    const supabaseService = createServiceSupabase();
     const supabase = await createServerSupabase();
 
     // Get document
@@ -571,8 +573,8 @@ export async function getDocumentSignedUrl(
       }
     }
 
-    // Generate signed URL (1 hour validity)
-    const { data, error: signError } = await supabase.storage
+    // Generate signed URL (1 hour validity) using service role to bypass RLS
+    const { data, error: signError } = await supabaseService.storage
       .from("documents")
       .createSignedUrl(document.file_url, 3600);
 


### PR DESCRIPTION
Use the Supabase service role client to generate signed URLs for
document files, bypassing row-level security (RLS). Previously the
server Supabase client was used, which could fail when RLS prevented
access during URL generation. Creating a service client ensures the
signed URL can be created reliably (1 hour validity) while keeping
regular server client usage for document retrieval logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 문서 다운로드/미리보기용 서명 URL 생성의 안정성을 개선하여 간헐적 권한 오류로 접근이 차단되던 문제를 해소했습니다.
  - 링크가 만료 조건·완료 상태·비밀번호 보호 조건을 충족하는 경우에도 예외적으로 실패하던 상황을 줄여 보다 일관된 접근을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->