### PR TITLE
✨chore: switch to server supabase client and clean up logs

### DIFF
--- a/lib/paddle/process-webhook.ts
+++ b/lib/paddle/process-webhook.ts
@@ -6,7 +6,7 @@ import {
   SubscriptionCreatedEvent,
   SubscriptionUpdatedEvent,
 } from "@paddle/paddle-node-sdk";
-import { createClient } from "@/lib/supabase/server";
+import { createServerSupabase } from "@/lib/supabase/server";
 import { PADDLE_PRICE_TIERS } from "./pricing-config";
 
 export class ProcessWebhook {
@@ -30,7 +30,7 @@ export class ProcessWebhook {
   private async updateSubscriptionData(
     eventData: SubscriptionCreatedEvent | SubscriptionUpdatedEvent
   ) {
-    const supabase = await createClient();
+    const supabase = await createServerSupabase();
 
     try {
       // 1. customer_id로 customers 테이블에서 user_id 조회
@@ -135,7 +135,10 @@ export class ProcessWebhook {
         .eq("id", customerData.user_id);
 
       if (userUpdateError) {
-        console.error("Failed to update user's current_subscription_id:", userUpdateError);
+        console.error(
+          "Failed to update user's current_subscription_id:",
+          userUpdateError
+        );
       }
 
       console.log(
@@ -150,12 +153,15 @@ export class ProcessWebhook {
   private async updateCustomerData(
     eventData: CustomerCreatedEvent | CustomerUpdatedEvent
   ) {
-    const supabase = await createClient();
+    const supabase = await createServerSupabase();
 
     try {
       // 이메일로 사용자 찾기 (Supabase Auth Admin API 사용)
-      const { data: { users }, error: userError } = await supabase.auth.admin.listUsers();
-      const user = users?.find(u => u.email === eventData.data.email);
+      const {
+        data: { users },
+        error: userError,
+      } = await supabase.auth.admin.listUsers();
+      const user = users?.find((u) => u.email === eventData.data.email);
 
       const { error } = await supabase
         .from("customers")


### PR DESCRIPTION
Use server-side Supabase client factory instead of generic client
- Replace createClient with createServerSupabase in webhook processing to
  ensure server-context auth and proper environment usage when handling
  Paddle webhooks.
- Update both updateSubscriptionData and updateCustomerData to call the
  server-specific creator.

Improve logging and formatting for readability
- Split long console.error call into multiple arguments for clearer stack
  output.
- Reformat destructuring and arrow function spacing in user lookup for
  consistent code style.

These changes fix incorrect client usage in server handlers and tidy
up code formatting to reduce runtime issues and improve maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 서버 환경에 맞는 데이터베이스 클라이언트 초기화 방식으로 전환하여 웹훅 기반 결제/구독 동기화 안정성을 개선했습니다.
  * 사용자 조회 및 구독/고객 업데이트 로직을 정리해 오류 대응과 유지보수성을 높였습니다.
  * 오류 로그 포맷을 개선해 문제 진단이 더 수월해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->