### PR TITLE
✨ feat(m): exclude Paddle webhook from middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -13,7 +13,8 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
      * - .*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$ (image files)
+     * - api/webhook (Paddle webhook endpoint)
      */
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|api/webhook|.*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
Add api/webhook to the middleware exclusion list so the Paddle
webhook endpoint bypasses middleware routing. This prevents the
middleware from interfering with raw webhook requests (e.g.
signature verification, body parsing expectations) and ensures the
webhook receives unmodified requests for correct processing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 웹훅 경로가 미들웨어에 의해 가로채지 않도록 라우팅 예외를 추가했습니다. 이제 /api/webhook 요청이 안정적으로 전달되어 외부 서비스 연동의 신뢰성이 향상되고, 의도치 않은 인증/리다이렉션 적용이 방지됩니다. 그 결과 알림 지연·실패가 줄어들며, 백그라운드 동기화, 결제/구독 갱신, 상태 업데이트가 더 일관되게 반영됩니다. 가시적 UI 변경은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->