### PR TITLE
✨ feat: switch to service Supabase client in Paddle webhook

### DIFF
--- a/lib/paddle/process-webhook.ts
+++ b/lib/paddle/process-webhook.ts
@@ -6,7 +6,7 @@ import {
   SubscriptionCreatedEvent,
   SubscriptionUpdatedEvent,
 } from "@paddle/paddle-node-sdk";
-import { createServerSupabase } from "@/lib/supabase/server";
+import { createServiceSupabase } from "@/lib/supabase/server";
 import { PADDLE_PRICE_TIERS } from "./pricing-config";
 
 export class ProcessWebhook {
@@ -30,7 +30,7 @@ export class ProcessWebhook {
   private async updateSubscriptionData(
     eventData: SubscriptionCreatedEvent | SubscriptionUpdatedEvent
   ) {
-    const supabase = await createServerSupabase();
+    const supabase = createServiceSupabase();
 
     try {
       // 1. customer_id로 customers 테이블에서 user_id 조회
@@ -199,7 +199,7 @@ export class ProcessWebhook {
   private async updateCustomerData(
     eventData: CustomerCreatedEvent | CustomerUpdatedEvent
   ) {
-    const supabase = await createServerSupabase();
+    const supabase = createServiceSupabase();
 
     try {
       // 이메일로 사용자 찾기 (Supabase Auth Admin API 사용)


### PR DESCRIPTION
Use createServiceSupabase instead of createServerSupabase in the
Paddle webhook processor to obtain the Supabase client synchronously.
Update occurrences in process-webhook.ts where subscription and
customer webhook handlers initialize Supabase.

Why:
- The webhook handlers run in a backend/service context and require a
  service-level Supabase client (with admin privileges) rather than the
  server-side helper that may expect a request/session bound instance.
- Using createServiceSupabase removes unnecessary async initialization
  and clarifies intent, reducing potential auth/permission issues when
  updating customers and subscriptions from Paddle webhooks.