### PR TITLE
✨ feat: stabilize pricing & usage display logic

### DIFF
--- a/components/dashboard/usage-widget.tsx
+++ b/components/dashboard/usage-widget.tsx
@@ -104,7 +104,7 @@ export function UsageWidget() {
     );
   }
 
-  if (error || !limits || !subscription) {
+  if (error || !limits) {
     return (
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <Card>
@@ -146,6 +146,7 @@ export function UsageWidget() {
   const isMonthlyNearLimit = monthlyProgress >= 80;
   const isActiveNearLimit = activeProgress >= 80;
 
+  const planName = subscription?.plan?.name ?? "Free";
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
       <Card>
@@ -161,15 +162,8 @@ export function UsageWidget() {
                   <ChevronDown className="h-4 w-4 text-muted-foreground" />
                 )}
               </div>
-              <Badge
-                variant={
-                  subscription.plan.name === "Free" ? "secondary" : "default"
-                }
-              >
-                {subscription.plan.name === "Free"
-                  ? t("usage.plan.free")
-                  : subscription.plan.name}{" "}
-                {t("usage.plan.suffix")}
+              <Badge variant={planName === "Free" ? "secondary" : "default"}>
+                {planName === "Free" ? t("usage.plan.free") : planName} {t("usage.plan.suffix")}
               </Badge>
             </div>
             <CardDescription>{t("usage.description")}</CardDescription>
@@ -239,8 +233,8 @@ export function UsageWidget() {
               )}
             </div>
 
-            {/* Upgrade CTA - Show only for Free and Pro plans */}
-            {subscription.plan.name !== "Enterprise" && (
+            {/* Upgrade CTA - Show only when not Enterprise or when no subscription (treat as Free) */}
+            {planName !== "Enterprise" && (
               <div className="pt-4 border-t">
                 <div className="flex items-center justify-between">
                   <div>
@@ -248,7 +242,7 @@ export function UsageWidget() {
                       {t("usage.upgrade.title")}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      {subscription.plan.name?.toLowerCase() === "free"
+                      {planName.toLowerCase() === "free"
                         ? t("usage.upgrade.description.free")
                         : t("usage.upgrade.description.pro")}
                     </p>
@@ -264,7 +258,7 @@ export function UsageWidget() {
             )}
 
             {/* Plan Features Summary */}
-            {subscription.plan.features &&
+            {subscription?.plan?.features &&
               subscription.plan.features.length > 0 && (
                 <div className="pt-4 border-t">
                   <p className="text-sm font-medium mb-2">

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -127,6 +127,9 @@ const translations: Record<Language, Record<string, string>> = {
     "pricing.pro.cta": "프로 시작하기",
     "pricing.popular": "인기",
     "pricing.perMonth": "월",
+    "pricing.perYear": "년",
+    "pricing.billing.monthly": "월간",
+    "pricing.billing.yearly": "연간",
     // Pricing limits (dynamic count)
     "pricing.limitPerMonth": "월 최대 {count}개 문서 생성",
     "pricing.limitUnlimitedPerMonth": "문서 무제한 생성",
@@ -141,6 +144,7 @@ const translations: Record<Language, Record<string, string>> = {
     "pricingPage.free": "무료",
     "pricingPage.contact": "문의",
     "pricingPage.perMonth": "/월",
+    "pricingPage.perYear": "/년",
     "pricingPage.documentsPerMonth": "월 문서 생성",
     "pricingPage.activeDocuments": "활성 문서",
     "pricingPage.unlimited": "무제한",
@@ -161,14 +165,9 @@ const translations: Record<Language, Record<string, string>> = {
       "{planName} 플랜이 선택되었습니다. 결제 모듈 연동 예정입니다.",
 
     // Pricing Page - Plan Details
-    "pricingPage.plans.free.description": "개인 사용자를 위한 기본 플랜",
-    "pricingPage.plans.free.feature1": "기본 문서 관리",
-    "pricingPage.plans.pro.description":
-      "전문가와 소규모 팀을 위한 향상된 기능",
-    "pricingPage.plans.pro.feature1": "이메일 알림",
-    "pricingPage.plans.enterprise.description":
-      "대규모 조직을 위한 완전한 솔루션",
-    "pricingPage.plans.enterprise.feature2": "전용 지원",
+    "pricingPage.plans.free.description": "개인 사용자를 위한 무료 플랜",
+    "pricingPage.plans.starter.description": "개인 또는 소규모 팀을 위한 플랜",
+    "pricingPage.plans.pro.description": "전문가를 위한 플랜",
 
     // Checkout Success
     "checkout.success.title": "결제가 완료되었습니다!",
@@ -940,6 +939,9 @@ const translations: Record<Language, Record<string, string>> = {
     "pricing.pro.cta": "Go Pro",
     "pricing.popular": "Popular",
     "pricing.perMonth": "/month",
+    "pricing.perYear": "/year",
+    "pricing.billing.monthly": "monthly",
+    "pricing.billing.yearly": "yearly",
     // Pricing limits (dynamic count)
     "pricing.limitPerMonth": "Up to {count} documents per month",
     "pricing.limitUnlimitedPerMonth": "Unlimited documents per month",
@@ -954,6 +956,7 @@ const translations: Record<Language, Record<string, string>> = {
     "pricingPage.free": "Free",
     "pricingPage.contact": "Contact Us",
     "pricingPage.perMonth": "/month",
+    "pricingPage.perYear": "/year",
     "pricingPage.documentsPerMonth": "Monthly documents",
     "pricingPage.activeDocuments": "Active documents",
     "pricingPage.unlimited": "Unlimited",
@@ -975,19 +978,8 @@ const translations: Record<Language, Record<string, string>> = {
 
     // Pricing Page - Plan Details
     "pricingPage.plans.free.description": "Basic plan for individual users",
-    "pricingPage.plans.free.feature1": "Basic document management",
-    "pricingPage.plans.free.feature2": "Standard support",
-    "pricingPage.plans.pro.description":
-      "Enhanced features for professionals and small teams",
-    "pricingPage.plans.pro.feature1": "Email notifications",
-    "pricingPage.plans.pro.feature2": "Priority support",
-    "pricingPage.plans.pro.feature3": "Advanced analytics",
-    "pricingPage.plans.enterprise.description":
-      "Complete solution for large organizations",
-    "pricingPage.plans.enterprise.feature1": "Custom workflows",
-    "pricingPage.plans.enterprise.feature2": "Dedicated support",
-    "pricingPage.plans.enterprise.feature3": "API access",
-    "pricingPage.plans.enterprise.feature4": "SSO integration",
+    "pricingPage.plans.starter.description": "For individuals and small teams",
+    "pricingPage.plans.pro.description": "Enhanced features for professionals",
 
     // Checkout Success
     "checkout.success.title": "Payment Successful!",

--- a/lib/paddle/pricing-config.ts
+++ b/lib/paddle/pricing-config.ts
@@ -1,6 +1,6 @@
 export interface PaddlePriceTier {
   name: string;
-  id: "free" | "pro" | "enterprise";
+  id: "free" | "pro" | "starter";
   priceId: {
     month: string;
     year: string;
@@ -18,19 +18,19 @@ export const PADDLE_PRICE_TIERS: PaddlePriceTier[] = [
     },
   },
   {
+    name: "Starter",
+    id: "starter",
+    priceId: {
+      month: "pri_01k6t62f9p22z50pr5hy4mfk7j", // 실제 Paddle Price ID로 교체
+      year: "pri_01k6yr8v1904d21fcnq80w7a8c", // 실제 Paddle Price ID로 교체
+    },
+  },
+  {
     name: "Pro",
     id: "pro",
     priceId: {
       month: "pri_01k6fxz394tm9v7sx6vbdq6esw", // 실제 Paddle Price ID로 교체
       year: "pri_01k6hfe2186s3mr286txzssxyn", // 실제 Paddle Price ID로 교체
-    },
-  },
-  {
-    name: "Enterprise",
-    id: "enterprise",
-    priceId: {
-      month: "pri_enterprise_month", // 실제 Paddle Price ID로 교체
-      year: "pri_enterprise_year", // 실제 Paddle Price ID로 교체
     },
   },
 ];


### PR DESCRIPTION
Fix usage widget error handling and null-safety
  - Return early only when limits are missing (not when subscription is
    potentially undefined), preventing accidental hides of the widget.
  - Introduce a local planName = subscription?.plan?.name ?? "Free" to
    avoid repeated optional chaining and to treat missing subscription as
    Free consistently.
  - Use planName for Badge text/variant, upgrade CTA condition, and
    upgrade description branch to avoid crashes when subscription is
    undefined.
  - Guard feature list rendering with subscription?.plan?.features to
    prevent runtime errors.

- Update paddle pricing tiers and plan IDs
  - Replace previous ids/names to reflect a Starter/Pro mapping and update
    corresponding Paddle price IDs for month/year tiers.

- Improve home pricing logic and billing state
  - Add billingCycle state (monthly/yearly) to support billing toggles.
  - Make enterprise detection robust by checking monthly/yearly price
    fields for -1 sentinel values instead of a deprecated price_cents
    field.
  - Treat zero monthly_price as Free and map enterprise sentinel to a
    contact callout; continue to resolve Paddle prices for billable
    plans.

These changes prevent crashes when subscription data is missing, make
plan presentation more resilient, and align pricing configuration with
updated Paddle price IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 월간/연간 결제 전환 토글 및 연간 요금 표시 추가
  - 언어별 기능 목록 및 가격 라벨(월/년) 지원
  - 인기 요금제 표시 및 무료/문의 플로우 처리
- Bug Fixes
  - 구독 없음 상태에서도 기본 한도 제공 및 사용량 표시 개선
  - 결제 초기화 실패 시 경고 처리로 UX 안정화
- Refactor
  - 요금제 명칭 개편: Free → Free, Pro → Starter, Enterprise → Pro
  - 결제 티어/가격 매핑 업데이트 및 가격 산정 로직 정비
  - 번역 확장: 월간/연간 관련 키 및 문구 추가(ko/en)
- Style
  - 가격 카드/홈 섹션 레이아웃 및 라벨 정돈
  - 현재 요금제 표시 일관성 개선 및 불필요한 항목 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->