### PR TITLE
✨ feat: add PaymentMethodCard and subscription detail

### DIFF
--- a/components/bills/payment-method-card.tsx
+++ b/components/bills/payment-method-card.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CreditCard, RefreshCw } from "lucide-react";
+import { getPrimaryPaymentMethod } from "@/lib/paddle/get-payment-methods";
+import { getSubscriptions } from "@/lib/paddle/get-subscriptions";
+import { formatDateByLang } from "@/lib/date/format";
+import { useLanguage } from "@/contexts/language-context";
+import { Environments, initializePaddle, Paddle } from "@paddle/paddle-js";
+import { createPaymentMethodChangeTransaction } from "@/lib/paddle/get-payment-method-change-transaction";
+
+export function PaymentMethodCard() {
+  const { language } = useLanguage();
+  const [brand, setBrand] = useState<string | undefined>(undefined);
+  const [last4, setLast4] = useState<string | undefined>(undefined);
+  const [expiry, setExpiry] = useState<string | undefined>(undefined);
+  const [nextBilling, setNextBilling] = useState<string | undefined>(undefined);
+  const [loading, setLoading] = useState(true);
+  const [paddle, setPaddle] = useState<Paddle | undefined>(undefined);
+  const [updating, setUpdating] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const [pm, subs] = await Promise.all([
+          getPrimaryPaymentMethod(),
+          getSubscriptions(),
+        ]);
+        if (pm.method) {
+          setBrand(pm.method.brand);
+          setLast4(pm.method.last4);
+          if (pm.method.expiryMonth && pm.method.expiryYear) {
+            setExpiry(`${pm.method.expiryMonth}/${pm.method.expiryYear}`);
+          }
+        }
+        const first = subs.data && subs.data.length > 0 ? subs.data[0] : undefined;
+        if (first?.nextBilledAt) {
+          setNextBilling(formatDateByLang(first.nextBilledAt, "date", language));
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [language]);
+
+  useEffect(() => {
+    if (
+      process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN &&
+      process.env.NEXT_PUBLIC_PADDLE_ENV
+    ) {
+      initializePaddle({
+        token: process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN,
+        environment: process.env.NEXT_PUBLIC_PADDLE_ENV as Environments,
+      })
+        .then((p) => setPaddle(p))
+        .catch(() => setPaddle(undefined));
+    }
+  }, []);
+
+  const masked = last4 ? `**** **** **** ${last4}` : undefined;
+
+  async function handleUpdateCard() {
+    try {
+      setUpdating(true);
+      const res = await createPaymentMethodChangeTransaction();
+      if (res.transactionId && paddle) {
+        paddle.checkout.open({ transactionId: res.transactionId });
+      }
+    } finally {
+      setUpdating(false);
+    }
+  }
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <CreditCard className="h-4 w-4" /> Payment Method
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 h-full flex flex-col">
+        {loading ? (
+          <div className="space-y-2">
+            <div className="h-4 bg-muted rounded animate-pulse w-1/2" />
+            <div className="h-4 bg-muted rounded animate-pulse w-1/3" />
+          </div>
+        ) : (
+          <>
+            <div className="text-sm">
+              <div className="text-muted-foreground">Card</div>
+              <div className="font-medium">
+                {brand ? `${brand.toUpperCase()} ${masked || ""}` : "No card on file"}
+              </div>
+            </div>
+            {expiry && (
+              <div className="text-sm">
+                <div className="text-muted-foreground">Expiry</div>
+                <div className="font-medium">{expiry}</div>
+              </div>
+            )}
+            {nextBilling && (
+              <div className="text-sm">
+                <div className="text-muted-foreground">Next billing date</div>
+                <div className="font-medium">{nextBilling}</div>
+              </div>
+            )}
+            <Button onClick={handleUpdateCard} disabled={!paddle || updating} className="gap-2 mt-auto">
+              <RefreshCw className="h-4 w-4" />
+              {updating ? "Updating..." : "Update card"}
+            </Button>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/bills/payments-tab.tsx
+++ b/components/bills/payments-tab.tsx
@@ -9,6 +9,7 @@ import { paymentsColumns } from "@/components/bills/payments-columns";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 import { useLanguage } from "@/contexts/language-context";
+// Payment method details are shown in Subscriptions tab footer, not here
 
 export function PaymentsTab() {
   const { t } = useLanguage();
@@ -67,15 +68,11 @@ export function PaymentsTab() {
     );
   }
 
-  if (transactions.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-muted-foreground">{t("bills.noTransactions")}</p>
-      </div>
-    );
-  }
-
-  return (
+  return transactions.length === 0 ? (
+    <div className="text-center py-12">
+      <p className="text-muted-foreground">{t("bills.noTransactions")}</p>
+    </div>
+  ) : (
     <PaymentsDataTable
       columns={paymentsColumns}
       data={transactions}

--- a/components/bills/previous-payments.tsx
+++ b/components/bills/previous-payments.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { Transaction } from "@paddle/paddle-node-sdk";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useLanguage } from "@/contexts/language-context";
+import { parseMoney } from "@/lib/paddle/parse-money";
+import { Status } from "@/components/bills/status";
+import { formatDateByLang } from "@/lib/date/format";
+import { getTransactions } from "@/lib/paddle/get-transactions";
+
+export function PreviousPayments() {
+  const { t, language } = useLanguage();
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      const { data } = await getTransactions("", "");
+      setTransactions(data || []);
+    }
+    load();
+  }, []);
+
+  return (
+    <Card className="h-full">
+      <CardHeader>
+        <CardTitle>{t("bills.pastPayments")}</CardTitle>
+      </CardHeader>
+      <CardContent className="h-full">
+        {transactions.length === 0 ? (
+          <div className="text-center py-6 text-muted-foreground">
+            {t("bills.noTransactions")}
+          </div>
+        ) : (
+          (() => {
+            const tx = transactions[0];
+            return (
+              <div className="flex justify-between items-center py-2">
+                <div>
+                  <div className="font-medium">
+                    {tx.billedAt
+                      ? formatDateByLang(tx.billedAt, "date", language)
+                      : "-"}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {tx.details?.lineItems[0].product?.name}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="font-medium">
+                    {parseMoney(
+                      tx.details?.totals?.total,
+                      tx.currencyCode
+                    )}
+                  </div>
+                  <Status status={tx.status} />
+                </div>
+              </div>
+            );
+          })()
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/bills/subscription-detail.tsx
+++ b/components/bills/subscription-detail.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getSubscription } from "@/lib/paddle/get-subscription";
-import { getTransactions } from "@/lib/paddle/get-transactions";
-import type { Subscription, Transaction } from "@paddle/paddle-node-sdk";
+import type { Subscription } from "@paddle/paddle-node-sdk";
 import { LoadingScreen } from "@/components/bills/loading-screen";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
@@ -36,16 +35,15 @@ export function SubscriptionDetail({ subscriptionId }: Props) {
   const { t, language } = useLanguage();
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription | null>(null);
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  
   const [error, setError] = useState<string | null>(null);
   const [canceling, setCanceling] = useState(false);
 
   useEffect(() => {
     async function fetchData() {
       try {
-        const [subscriptionResponse, transactionsResponse] = await Promise.all([
+        const [subscriptionResponse] = await Promise.all([
           getSubscription(subscriptionId),
-          getTransactions(subscriptionId, ""),
         ]);
 
         if (subscriptionResponse.error) {
@@ -54,9 +52,7 @@ export function SubscriptionDetail({ subscriptionId }: Props) {
           setSubscription(subscriptionResponse.data);
         }
 
-        if (transactionsResponse.data) {
-          setTransactions(transactionsResponse.data);
-        }
+        
       } catch (err) {
         console.error("Error:", err);
         setError(t("bills.error.loadSubscriptionDetail"));
@@ -207,48 +203,7 @@ export function SubscriptionDetail({ subscriptionId }: Props) {
         </Card>
       )}
 
-      {/* Past Payments */}
-      {transactions.length > 0 && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t("bills.pastPayments")}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {transactions.slice(0, 5).map((transaction) => (
-                <div
-                  key={transaction.id}
-                  className="flex justify-between items-center py-2 border-b last:border-b-0"
-                >
-                  <div>
-                    <div className="font-medium">
-                      {transaction.billedAt
-                        ? formatDateByLang(
-                            transaction.billedAt,
-                            "date",
-                            language
-                          )
-                        : "-"}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
-                      {transaction.details?.lineItems[0].product?.name}
-                    </div>
-                  </div>
-                  <div className="text-right">
-                    <div className="font-medium">
-                      {parseMoney(
-                        transaction.details?.totals?.total,
-                        transaction.currencyCode
-                      )}
-                    </div>
-                    <Status status={transaction.status} />
-                  </div>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      {/* Past Payments moved to SubscriptionsTab footer */}
     </div>
   );
 }

--- a/components/bills/subscriptions-tab.tsx
+++ b/components/bills/subscriptions-tab.tsx
@@ -9,12 +9,15 @@ import { SubscriptionDetail } from "@/components/bills/subscription-detail";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
 import { useLanguage } from "@/contexts/language-context";
+import { PaymentMethodCard } from "@/components/bills/payment-method-card";
+import { PreviousPayments } from "@/components/bills/previous-payments";
 
 export function SubscriptionsTab() {
   const { t } = useLanguage();
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [txError, setTxError] = useState<string | null>(null);
 
   useEffect(() => {
     async function fetchSubscriptions() {
@@ -37,6 +40,8 @@ export function SubscriptionsTab() {
     fetchSubscriptions();
   }, []);
 
+  // Previous payments load within PreviousPayments component
+
   if (loading) {
     return <LoadingScreen />;
   }
@@ -55,5 +60,15 @@ export function SubscriptionsTab() {
   }
 
   // For now, show only the first subscription
-  return <SubscriptionDetail subscriptionId={subscriptions[0].id} />;
+  return (
+    <div className="space-y-6">
+      <SubscriptionDetail subscriptionId={subscriptions[0].id} />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 auto-rows-fr items-stretch">
+        <div className="h-full">
+          <PaymentMethodCard />
+        </div>
+        <div className="h-full">{txError ? <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{txError}</AlertDescription></Alert> : <PreviousPayments />}</div>
+      </div>
+    </div>
+  );
 }

--- a/lib/paddle/get-payment-method-change-transaction.ts
+++ b/lib/paddle/get-payment-method-change-transaction.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { getCustomerId } from "@/lib/paddle/get-customer-id";
+import { getPaddleInstance } from "@/lib/paddle/get-paddle-instance";
+
+export async function createPaymentMethodChangeTransaction(): Promise<{
+  transactionId?: string;
+  error?: string;
+}> {
+  try {
+    const customerId = await getCustomerId();
+    if (!customerId) return { error: "Missing customer" };
+    const paddle = getPaddleInstance();
+    // Find an active subscription for this customer
+    const subs = paddle.subscriptions.list({ customerId: [customerId], perPage: 5 });
+    const list = await subs.next();
+    const active = (list || []).find((s: any) => (s.status || "").toLowerCase() === "active");
+    const target = active || (list || [])[0];
+    if (!target) return { error: "No subscription found" };
+    const tx = await paddle.subscriptions.getPaymentMethodChangeTransaction(target.id);
+    return { transactionId: tx.id };
+  } catch (e: any) {
+    console.error("Error creating payment method change transaction:", e);
+    return { error: e?.message || "Failed to create payment method change transaction" };
+  }
+}
+

--- a/lib/paddle/get-payment-methods.ts
+++ b/lib/paddle/get-payment-methods.ts
@@ -1,0 +1,49 @@
+"use server";
+
+import { getCustomerId } from "@/lib/paddle/get-customer-id";
+import { getPaddleInstance } from "@/lib/paddle/get-paddle-instance";
+import { parseSDKResponse } from "@/lib/paddle/data-helpers";
+
+export interface PaymentMethodSummary {
+  id: string;
+  brand?: string;
+  last4?: string;
+  expiryMonth?: number;
+  expiryYear?: number;
+  savedAt?: string;
+}
+
+export async function getPrimaryPaymentMethod(): Promise<{
+  method: PaymentMethodSummary | null;
+  error?: string;
+}> {
+  try {
+    const customerId = await getCustomerId();
+    if (!customerId) return { method: null };
+
+    const paddle = getPaddleInstance();
+    const collection = paddle.paymentMethods.list(customerId, { perPage: 10 });
+    const list = await collection.next();
+    const methods = parseSDKResponse(list || []);
+    if (!methods || methods.length === 0) return { method: null };
+
+    // Pick the most recently saved
+    const sorted = methods.sort((a: any, b: any) =>
+      (b.savedAt || "").localeCompare(a.savedAt || "")
+    );
+    const m = sorted[0];
+    const summary: PaymentMethodSummary = {
+      id: m.id,
+      brand: m.card?.type,
+      last4: m.card?.last4,
+      expiryMonth: m.card?.expiryMonth,
+      expiryYear: m.card?.expiryYear,
+      savedAt: m.savedAt,
+    };
+    return { method: summary };
+  } catch (e: any) {
+    console.error("Error fetching payment methods:", e);
+    return { method: null, error: e?.message || "Failed to fetch payment methods" };
+  }
+}
+


### PR DESCRIPTION
- Add new PaymentMethodCard component to show primary card info,
  next billing date, and initiate payment-method-change flow. This
  encapsulates payment UI and Paddle integration (Paddle JS init,
  createPaymentMethodChangeTransaction) for a cleaner UX and reuse.

- Remove transactions fetching and display from SubscriptionDetail.
  Drop Transaction type import and related state/logic. Past payments
  are now moved to the SubscriptionsTab footer (simplifies detail
  view and reduces duplicate data fetching).

- Keep error/loading/cancel flows in subscription detail intact while
  tidying up Promise.all usage and state initialization.

Why:
- Separate responsibility: move payment-method UI into its own
  component to improve modularity and make SubscriptionDetail focused
  on subscription metadata.
- Reduce unnecessary data fetching on the detail page and avoid
  rendering duplicated past-payment lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 결제 수단 카드가 추가되어 현재 카드 정보(브랜드, 끝자리, 만료일)와 다음 결제일을 확인하고, 버튼으로 카드 정보를 업데이트할 수 있습니다.
  - 과거 결제 내역 카드가 추가되어 최근 결제 요약(결제일, 상품명, 금액, 상태)을 표시합니다.
  - 구독 탭이 2열 레이아웃으로 확장되어 결제 수단과 과거 결제를 함께 볼 수 있으며, 결제 처리 오류 시 경고가 표시됩니다.
- 리팩터링
  - 결제 내역 탭의 빈 상태 렌더링 로직을 간소화했습니다.
  - 구독 상세에서 별도 거래 내역 로딩을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->