### PR TITLE
✨ fix(payment): handle paddle/init errors and use Checkout.open

### DIFF
--- a/components/bills/payment-method-card.tsx
+++ b/components/bills/payment-method-card.tsx
@@ -9,6 +9,7 @@ import { getSubscriptions } from "@/lib/paddle/get-subscriptions";
 import { formatDateByLang } from "@/lib/date/format";
 import { useLanguage } from "@/contexts/language-context";
 import { Environments, initializePaddle, Paddle } from "@paddle/paddle-js";
+import { toast } from "@/components/ui/use-toast";
 import { createPaymentMethodChangeTransaction } from "@/lib/paddle/get-payment-method-change-transaction";
 
 export function PaymentMethodCard() {
@@ -66,9 +67,16 @@ export function PaymentMethodCard() {
     try {
       setUpdating(true);
       const res = await createPaymentMethodChangeTransaction();
-      if (res.transactionId && paddle) {
-        paddle.checkout.open({ transactionId: res.transactionId });
+      if (!res.transactionId) {
+        toast({ title: "Failed to start card update", description: res.error || "No transaction created" });
+        return;
       }
+      if (!paddle) {
+        toast({ title: "Paddle not initialized", description: "Please try again later." });
+        return;
+      }
+      // Use correct Paddle JS API (capitalized Checkout)
+      paddle.Checkout.open({ transactionId: res.transactionId });
     } finally {
       setUpdating(false);
     }


### PR DESCRIPTION
- Add toast notifications for failure cases when creating a payment
  method change transaction or when Paddle is not initialized, so users
  receive immediate feedback instead of silent failures.
- Prevent attempting to open checkout when transactionId is missing.
- Use the correct Paddle JS API entrypoint (capitalize Checkout) to open
  the checkout modal.
- Import toast utility and adjust control flow to set updating state
  correctly while preserving error handling.

These changes improve UX by surfacing errors and ensure the Paddle
checkout is invoked correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 카드 결제수단 업데이트 시 거래 ID가 없거나 결제 모듈 미초기화 상태에서 발생하던 실패 케이스를 방지했습니다.
  - 위 상황에서 명확한 토스트 메시지로 오류 원인을 안내합니다.
  - 유효한 거래 ID와 초기화된 결제 모듈이 확인된 경우에만 결제창을 안전하게 호출하도록 개선했습니다.
  - 전반적인 결제 업데이트 흐름의 안정성과 신뢰성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->