### PR TITLE
✨ feat(payment): increase PM fetch & refresh after checkout

### DIFF
--- a/lib/paddle/get-payment-methods.ts
+++ b/lib/paddle/get-payment-methods.ts
@@ -22,7 +22,10 @@ export async function getPrimaryPaymentMethod(): Promise<{
     if (!customerId) return { method: null };
 
     const paddle = getPaddleInstance();
-    const collection = paddle.paymentMethods.list(customerId, { perPage: 10 });
+    const collection = paddle.paymentMethods.list(customerId, {
+      perPage: 50,
+      supportsCheckout: true,
+    });
     const list = await collection.next();
     const methods = parseSDKResponse(list || []);
     if (!methods || methods.length === 0) return { method: null };
@@ -46,4 +49,3 @@ export async function getPrimaryPaymentMethod(): Promise<{
     return { method: null, error: e?.message || "Failed to fetch payment methods" };
   }
 }
-


### PR DESCRIPTION
Increase Paddle payment methods fetch page size to 50 and enable
supportsCheckout to ensure the SDK returns checkout-capable methods.
This improves detection of primary payment methods when users add
or update cards during checkout.

Add Paddle eventCallback and a fallback delayed refresh in the payment
method card component to update displayed card brand, last4 and expiry
immediately after checkout completes. This ensures the UI reflects
recent changes even if SDK events are missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 체크아웃 완료 후 결제수단 카드가 즉시 갱신되지 않거나 반영이 누락되던 문제를 개선했습니다. 이벤트 수신 시 기본 결제수단 정보(브랜드, 끝 4자리, 만료일)를 자동 업데이트하고, 이벤트 누락 대비로 짧은 지연 후 재조회하여 UI 정확도를 높였습니다.
  * 결제수단 목록 조회 범위를 확대해 누락 가능성을 줄이고, 기본 결제수단을 더 안정적으로 식별·표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->