### PR TITLE
✨ feat(payment prefer card and accept customerId override

### DIFF
--- a/components/bills/payment-method-card.tsx
+++ b/components/bills/payment-method-card.tsx
@@ -25,10 +25,10 @@ export function PaymentMethodCard() {
   useEffect(() => {
     async function load() {
       try {
-        const [pm, subs] = await Promise.all([
-          getPrimaryPaymentMethod(),
-          getSubscriptions(),
-        ]);
+        const subs = await getSubscriptions();
+        const first = subs.data && subs.data.length > 0 ? subs.data[0] : undefined;
+        const customerId = first?.customerId;
+        const pm = await getPrimaryPaymentMethod(customerId);
         if (pm.method) {
           setBrand(pm.method.brand);
           setLast4(pm.method.last4);
@@ -36,7 +36,6 @@ export function PaymentMethodCard() {
             setExpiry(`${pm.method.expiryMonth}/${pm.method.expiryYear}`);
           }
         }
-        const first = subs.data && subs.data.length > 0 ? subs.data[0] : undefined;
         if (first?.nextBilledAt) {
           setNextBilling(formatDateByLang(first.nextBilledAt, "date", language));
         }
@@ -58,7 +57,10 @@ export function PaymentMethodCard() {
         eventCallback: async (event) => {
           // When checkout completes, refresh card data
           if (event?.name === "checkout.completed") {
-            const pm = await getPrimaryPaymentMethod();
+            const subs = await getSubscriptions();
+            const first = subs.data && subs.data.length > 0 ? subs.data[0] : undefined;
+            const customerId = first?.customerId;
+            const pm = await getPrimaryPaymentMethod(customerId);
             if (pm.method) {
               setBrand(pm.method.brand);
               setLast4(pm.method.last4);
@@ -92,7 +94,10 @@ export function PaymentMethodCard() {
       paddle.Checkout.open({ transactionId: res.transactionId });
       // Also set a delayed refresh in case events are missed
       setTimeout(async () => {
-        const pm = await getPrimaryPaymentMethod();
+        const subs = await getSubscriptions();
+        const first = subs.data && subs.data.length > 0 ? subs.data[0] : undefined;
+        const customerId = first?.customerId;
+        const pm = await getPrimaryPaymentMethod(customerId);
         if (pm.method) {
           setBrand(pm.method.brand);
           setLast4(pm.method.last4);


### PR DESCRIPTION
Update Paddle payment method retrieval and usage to prefer card-based
methods and allow passing a customerId override when fetching the
primary payment method.

- lib/paddle/get-payment-methods.ts
  - Add optional overrideCustomerId parameter and use it before calling
    getCustomerId() so callers can supply a specific customer context.
  - Remove supportsCheckout filter and fetch up to 50 methods.
  - Change selection to prefer methods that include card data and sort
    by updatedAt (falling back to savedAt) to pick the most recently
    updated card. Fall back to the first method if no card methods exist.

- components/bills/payment-method-card.tsx
  - Fetch subscriptions first to derive customerId and pass it into
    getPrimaryPaymentMethod, ensuring we query the correct customer's
    payment methods in all refresh paths (initial load, checkout event,
    and delayed refresh).
  - Reorder logic to avoid duplicate subscription lookups and ensure
    customerId is available before requesting payment methods.

These changes improve correctness when multiple customers/subscriptions
are present and ensure card methods are prioritized for display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 기본 결제수단이 잘못 표시되거나 갱신되지 않던 문제를 개선했습니다.
  - 구독 정보 기반으로 다음 결제일 표시의 정확성과 일관성을 높였습니다.
  - 체크아웃 완료 후 결제수단/구독 정보가 최신 상태로 반영되도록 했습니다.
- Refactor
  - 데이터 로딩 순서를 정비해 구독 → 결제수단 흐름으로 안정성을 강화했습니다.
  - 카드 결제수단 우선 선택 로직으로 사용자에게 더 관련성 높은 결제수단을 노출합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->