### PR TITLE
✨ feat: surface transactions and pass payment details to UI

### DIFF
--- a/components/bills/previous-payments.tsx
+++ b/components/bills/previous-payments.tsx
@@ -1,25 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import type { Transaction } from "@paddle/paddle-node-sdk";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useLanguage } from "@/contexts/language-context";
 import { parseMoney } from "@/lib/paddle/parse-money";
 import { Status } from "@/components/bills/status";
 import { formatDateByLang } from "@/lib/date/format";
-import { getTransactions } from "@/lib/paddle/get-transactions";
 
-export function PreviousPayments() {
+interface PreviousPaymentsProps {
+  transactions?: Transaction[];
+}
+
+export function PreviousPayments({ transactions = [] }: PreviousPaymentsProps) {
   const { t, language } = useLanguage();
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-
-  useEffect(() => {
-    async function load() {
-      const { data } = await getTransactions("", "");
-      setTransactions(data || []);
-    }
-    load();
-  }, []);
 
   return (
     <Card className="h-full">

--- a/components/bills/subscriptions-tab.tsx
+++ b/components/bills/subscriptions-tab.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { getSubscriptions } from "@/lib/paddle/get-subscriptions";
-import type { Subscription } from "@paddle/paddle-node-sdk";
+import type { Subscription, Transaction } from "@paddle/paddle-node-sdk";
 import { LoadingScreen } from "@/components/bills/loading-screen";
 import { NoSubscriptionView } from "@/components/bills/no-subscription-view";
 import { SubscriptionDetail } from "@/components/bills/subscription-detail";
@@ -11,10 +11,12 @@ import { AlertCircle } from "lucide-react";
 import { useLanguage } from "@/contexts/language-context";
 import { PaymentMethodCard } from "@/components/bills/payment-method-card";
 import { PreviousPayments } from "@/components/bills/previous-payments";
+import { getTransactions } from "@/lib/paddle/get-transactions";
 
 export function SubscriptionsTab() {
   const { t } = useLanguage();
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
@@ -37,7 +39,17 @@ export function SubscriptionsTab() {
       }
     }
 
+    async function fetchTransactions() {
+      try {
+        const { data } = await getTransactions("", "");
+        setTransactions(data || []);
+      } catch (err) {
+        console.error("Error fetching transactions:", err);
+      }
+    }
+
     fetchSubscriptions();
+    fetchTransactions();
   }, []);
 
   // Previous payments load within PreviousPayments component
@@ -65,9 +77,9 @@ export function SubscriptionsTab() {
       <SubscriptionDetail subscriptionId={subscriptions[0].id} />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 auto-rows-fr items-stretch">
         <div className="h-full">
-          <PaymentMethodCard />
+          <PaymentMethodCard transactions={transactions} subscription={subscriptions[0]} />
         </div>
-        <div className="h-full">{txError ? <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{txError}</AlertDescription></Alert> : <PreviousPayments />}</div>
+        <div className="h-full">{txError ? <Alert variant="destructive"><AlertCircle className="h-4 w-4" /><AlertDescription>{txError}</AlertDescription></Alert> : <PreviousPayments transactions={transactions} />}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
Add transaction fetching and thread transaction data through billing UI
so payment method and previous payments components can show real
payment details.

- Import Transaction type and getTransactions() in subscriptions tab.
- Fetch transactions alongside subscriptions and store in state.
- Pass transactions and the selected subscription to PaymentMethodCard.
- Forward transactions into PreviousPayments so it can render actual
  history.
- Update PaymentMethodCard to accept transactions/subscription props,
  extract payment method details from transactions, and populate card
  brand, last4 and expiry from the first valid payment entry.
- Remove previous server-only payment-method lookups; rely on fetched
  transactions to reduce redundant requests and simplify flow.

This enables showing accurate card info and payment history without
extra network calls and prepares for further UX improvements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 결제수단 카드가 최신 거래·구독 데이터를 기반으로 카드 브랜드, 끝자리, 만료일 및 다음 결제일을 더 정확하게 표시합니다.
  - 결제(체크아웃) 완료 시 페이지가 자동 새로고침되어 결제수단과 구독/거래 내역이 즉시 반영됩니다.
  - 이전 결제 내역이 제공된 거래 데이터를 직접 사용해 더 신뢰성 있게 표시됩니다.
  - 초기 로딩 시 거래 데이터도 함께 불러와 결제수단 및 이전 결제 컴포넌트에 전달하여 화면 일관성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->