### PR TITLE
✨ feat(i18n): Korean terms for paid services wording

### DIFF
--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -418,7 +418,7 @@ const translations: Record<Language, Record<string, string>> = {
     "term.article2.item5":
       "서명자: 서명 요청자로부터 전자문서에 서명을 요청받거나 서명을 하는 이용자를 말합니다.",
     "term.article2.item6":
-      "유료서비스: 운영자가 제공하는 서비스 중 회원이 요금을 결제한 후 이용할 수 있는 서비스(추후 도입 가능)를 말합니다.",
+      "유료서비스: 운영자가 제공하는 서비스 중 회원이 요금을 결제한 후 이용할 수 있는 서비스를 말합니다.",
 
     "term.article3.title": "제3조 (약관의 게시와 개정)",
     "term.article3.para1":
@@ -542,9 +542,8 @@ const translations: Record<Language, Record<string, string>> = {
       "운영자가 이용계약을 해지하는 경우 운영자는 회원에게 해지사유를 밝혀 통지하며, 회원은 통지일로부터 7일 이내 이의를 제기할 수 있습니다.",
 
     // Chapter 4
-    "term.chapter4.title": "제4장 유료서비스 (추후 도입 시 적용)",
-    "term.chapter4.intro":
-      "현재 서비스는 무료로 제공되며, 향후 유료 서비스 도입 시 다음 규정이 적용됩니다.",
+    "term.chapter4.title": "제4장 유료서비스",
+    "term.chapter4.intro": "유료 서비스 이용 시 다음 규정이 적용됩니다.",
 
     "term.article16.title": "제16조 (유료서비스 이용 계약 및 요금제)",
     "term.article16.para1":


### PR DESCRIPTION
Refine wording in Korean terms to remove tentative phrasing and
stream descriptions of paid services.

- Removehetical "추후 도입 가능" from the paid service
  definition so it reads as a concrete description of services
  that require payment.
- Simplify chapter title and intro for Chapter 4 from provisional
  "유료서비스 (추후 도 시 적용)" and explanatory sentence to
  concise "제4장 유료서비스" and "유료 서비스 이용 시 규정이
  적용됩니다." to reflect active policy text.

These changes improve clarity and remove language in the
terms to better represent the current/legalized wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 문서화
  * 약관 번역 문구를 간결화했습니다. 한국어 term.article2.item6에서 “추후 도입” 관련 괄호 문구를 제거해 결제 후 이용 가능 서비스로 명확히 표현했습니다.
  * 제4장 제목/소개를 간소화했습니다.
    - KO: “제4장 유료서비스 (추후 도입 시 적용)” → “제4장 유료서비스”, 소개 문구 간결화
    - EN: “Chapter 4: Paid Services (Applied When Introduced)” → “Chapter 4: Paid Services”, 소개 문구 간결화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->