### PR TITLE
✨ feat(i18n): add checkout back button text and use in header

### DIFF
--- a/components/checkout/checkout-header.tsx
+++ b/components/checkout/checkout-header.tsx
@@ -1,8 +1,13 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/language-context";
 import { ChevronLeft } from "lucide-react";
 import Link from "next/link";
 
 export function CheckoutHeader() {
+  const { t } = useLanguage();
+
   return (
     <div>
       <Link href={"/pricing"} className="inline-block">
@@ -13,7 +18,7 @@ export function CheckoutHeader() {
           }
         >
           <ChevronLeft className="w-4 h-4" />
-          <span className="text-sm">요금제 페이지로 돌아가기</span>
+          <span className="text-sm">{t("checkout.backButton")}</span>
         </Button>
       </Link>
     </div>

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -169,6 +169,9 @@ const translations: Record<Language, Record<string, string>> = {
     "pricingPage.plans.starter.description": "개인 또는 소규모 팀을 위한 플랜",
     "pricingPage.plans.pro.description": "전문가를 위한 플랜",
 
+    // Checkout Page
+    "checkout.backButton": "요금제 페이지로 돌아가기",
+
     // Checkout Success
     "checkout.success.title": "결제가 완료되었습니다!",
     "checkout.success.message":
@@ -988,6 +991,9 @@ const translations: Record<Language, Record<string, string>> = {
     "pricingPage.plans.basic.description": "Basic plan for individual users",
     "pricingPage.plans.starter.description": "For individuals and small teams",
     "pricingPage.plans.pro.description": "Enhanced features for professionals",
+
+    // Checkout Page
+    "checkout.backButton": "Go Back",
 
     // Checkout Success
     "checkout.success.title": "Payment Successful!",


### PR DESCRIPTION
Add a localized "checkout.back" string to Korean and English locale
files so the checkout header can display a translatable back button label.
Enable client-side usage in the CheckoutHeader component and consume the
language context to render the localized text.

Why:
- Centralize UI text into in to support multiple languages and future
  translations.
- Replace hard-coded Korean label with a context-driven string to ensure
  consistency and allow runtime locale switching.
- Mark CheckoutHeader as a client component to permit hooks usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 체크아웃 페이지 헤더의 뒤로가기 버튼이 다국어를 지원합니다. 앱/브라우저 언어 설정에 따라 한국어 “요금제 페이지로 돌아가기” 또는 영어 “Go Back”으로 자동 표시됩니다. 버튼 동작은 기존과 동일하며, 표시 문구만 현지화되었습니다.
- Chores
  - 한국어/영어 번역 리소스에 “checkout.backButton” 키를 추가해 문구 관리 일관성과 향후 언어 확장을 용이하게 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->