### PR TITLE
✨ feat(register): add registration success page redirect

### DIFF
--- a/app/(auth)/register/actions.ts
+++ b/app/(auth)/register/actions.ts
@@ -77,5 +77,5 @@ export async function register(_: any, formData: FormData) {
   }
 
   revalidatePath("/", "layout");
-  redirect("/dashboard");
+  redirect("/register/success");
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import RegisterPage from "./RegisterPage";
 
 export default function Register() {

--- a/app/(auth)/register/success/page.tsx
+++ b/app/(auth)/register/success/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useLanguage } from "@/contexts/language-context";
+import { CheckCircle2, FileSignature, Mail } from "lucide-react";
+import Link from "next/link";
+
+export default function RegisterSuccessPage() {
+  const { t } = useLanguage();
+
+  return (
+    <div className="flex min-h-screen">
+      {/* Left side - Pattern background */}
+      <div className="hidden md:block md:w-1/2 relative bg-primary/5 overflow-hidden">
+        <div className="absolute inset-0 bg-dot-pattern opacity-30"></div>
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-primary/5"></div>
+        <div className="absolute inset-0 flex items-center justify-center p-12">
+          <div className="max-w-md text-center">
+            <FileSignature className="h-20 w-20 text-primary mx-auto mb-6" />
+            <h1 className="text-4xl font-bold mb-4 gradient-text">
+              {t("register.success.title")}
+            </h1>
+            <p className="text-lg text-muted-foreground">
+              {t("register.joinMessage")}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Right side - Success message */}
+      <div className="w-full md:w-1/2 flex flex-col">
+        <div className="flex justify-end p-4">
+          <Link href="/">
+            <Button variant="ghost" size="sm">
+              {t("register.backToHome")}
+            </Button>
+          </Link>
+        </div>
+
+        <div className="flex-1 flex items-center justify-center p-8">
+          <div className="w-full max-w-md space-y-8">
+            <div className="text-center">
+              <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 mb-6">
+                <CheckCircle2 className="h-8 w-8 text-primary" />
+              </div>
+
+              <h2 className="text-3xl font-bold tracking-tight mb-2">
+                {t("register.success.title")}
+              </h2>
+
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-primary/5 text-primary text-sm font-medium mb-6">
+                <Mail className="h-4 w-4" />
+                {t("register.success.emailSent")}
+              </div>
+            </div>
+
+            <div className="space-y-4 text-center">
+              <p className="text-muted-foreground">
+                {t("register.success.description")}
+              </p>
+
+              <p className="text-sm text-muted-foreground">
+                {t("register.success.checkSpam")}
+              </p>
+            </div>
+
+            <div className="space-y-4">
+              <Link href="/login" className="block">
+                <Button className="w-full bg-primary hover:bg-primary/90">
+                  {t("register.success.goToLogin")}
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -230,6 +230,16 @@ const translations: Record<Language, Record<string, string>> = {
     "register.privacyPolicy": "개인정보 처리방침",
     "register.privacyAgree2": "에 동의합니다.",
 
+    // Register Success
+    "register.success.title": "회원가입이 완료되었습니다!",
+    "register.success.subtitle": "이메일 인증",
+    "register.success.emailSent": "이메일 인증 메일이 발송되었습니다",
+    "register.success.description":
+      "가입하신 이메일 주소로 인증 메일이 발송되었습니다. 이메일을 확인하여 계정을 활성화해주세요.",
+    "register.success.checkSpam":
+      "메일이 보이지 않으면 스팸 폴더를 확인해주세요.",
+    "register.success.goToLogin": "로그인 화면으로",
+
     // Sign Page - Password Protection & Status
     "sign.password.title": "보안 문서",
     "sign.password.description": "이 문서는 비밀번호로 보호되어 있습니다.",
@@ -1054,6 +1064,16 @@ const translations: Record<Language, Record<string, string>> = {
     "register.terms": "Terms of Service",
     "register.privacyPolicy": "Privacy Policy",
     "register.privacyAgree2": ".",
+
+    // Register Success
+    "register.success.title": "Registration Complete!",
+    "register.success.subtitle": "Email Verification",
+    "register.success.emailSent": "Verification email has been sent",
+    "register.success.description":
+      "A verification email has been sent to your registered email address. Please check your email to activate your account.",
+    "register.success.checkSpam":
+      "If you don't see the email, please check your spam folder.",
+    "register.success.goToLogin": "Go to Login",
 
     // Sign Page - Password Protection & Status
     "sign.password.title": "Protected Document",

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -7,6 +7,7 @@ interface Routes {
 const publicRoutes: Routes = {
   "/login": true,
   "/register": true,
+  "/register/success": true,
   "/auth": true,
   "/error": true,
   "/": true,
@@ -21,6 +22,7 @@ const publicRoutes: Routes = {
 const publicOnlyRoutes: Routes = {
   "/login": true,
   "/register": true,
+  "/register/success": true,
   "/": true,
 };
 


### PR DESCRIPTION
Add a new success route and UI shown after completing registration.
- Create app/(auth)/register/success/page.tsx with a responsive
  two-column success screen that uses language context strings,
  icons, and actions to go to login or home. This provides clearer
  post-registration feedback and prompts email verification.
- Update registration action to redirect users to /register/success
  instead of /dashboard to ensure users see confirmation and next
  steps after signing up.
- Mark /register/success as public in lib/supabase/middleware.ts so
  unauthenticated users can view the success page.
- Add localization keys for the success page in contexts/language-
  context.tsx (Korean and English) to support i18n.
- Remove an unused Metadata import from app/(auth)/register/page.tsx.

These changes improve UX by guiding new users to verify their email
and preventing confusion about their next steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 회원가입 완료 후 이동 경로를 가입 완료 화면으로 변경.
  - 가입 완료 화면 추가: 성공 아이콘, 안내 메시지, 이메일 발송 뱃지, 홈으로/로그인 이동 버튼 제공.
  - 가입 완료 화면을 비로그인 사용자에게 공개하고, 로그인 사용자는 접근 시 리디렉션 처리.
  - 한국어/영어 번역 키 추가로 가입 완료 화면 문구 현지화.

- 스타일
  - 불필요한 타입 전용 임포트 정리.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->