### PR TITLE
✨ chore: refactor account deletion to use service role

### DIFF
--- a/app/(profile)/mypage/components/delete-account-form.tsx
+++ b/app/(profile)/mypage/components/delete-account-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { useLanguage } from "@/contexts/language-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,6 +18,7 @@ interface DeleteAccountFormProps {
 export default function DeleteAccountForm({ userEmail }: DeleteAccountFormProps) {
   const { t } = useLanguage();
   const { toast } = useToast();
+  const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [showForm, setShowForm] = useState(false);
   const [emailInput, setEmailInput] = useState("");
@@ -43,11 +45,13 @@ export default function DeleteAccountForm({ userEmail }: DeleteAccountFormProps)
             variant: "destructive",
           });
         } else {
-          // Success - user will be redirected by the server action
+          // Success - show toast and redirect immediately
           toast({
             title: t("mypage.dangerZone.deleteSuccess"),
-            description: "",
           });
+
+          // Redirect to home page immediately
+          router.push("/");
         }
       } catch (err) {
         console.error("Delete account error:", err);

--- a/app/(profile)/mypage/components/mypage-content.tsx
+++ b/app/(profile)/mypage/components/mypage-content.tsx
@@ -1,8 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Progress } from "@/components/ui/progress";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { AlertTriangle } from "lucide-react";
 import { useLanguage } from "@/contexts/language-context";
 import DeleteAccountForm from "./delete-account-form";
@@ -34,6 +42,7 @@ interface MyPageContentProps {
 
 export function MyPageContent({ user, profile, subscription, usage }: MyPageContentProps) {
   const { t, language } = useLanguage();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   // Display name and avatar
   const displayName = profile?.name || user.user_metadata?.full_name || user.email;
@@ -86,6 +95,14 @@ export function MyPageContent({ user, profile, subscription, usage }: MyPageCont
                 <span className="text-muted-foreground">{t("mypage.profile.joinedAt")}</span>
                 <span className="font-medium">{joinedDate}</span>
               </div>
+            </div>
+            <div className="pt-2">
+              <button
+                onClick={() => setIsDeleteDialogOpen(true)}
+                className="text-xs text-muted-foreground hover:text-destructive transition-colors underline"
+              >
+                {t("mypage.dangerZone.deleteAccount")}
+              </button>
             </div>
           </CardContent>
         </Card>
@@ -167,19 +184,21 @@ export function MyPageContent({ user, profile, subscription, usage }: MyPageCont
         </CardContent>
       </Card>
 
-      {/* Danger Zone */}
-      <Card className="border-destructive">
-        <CardHeader>
-          <CardTitle className="text-destructive flex items-center gap-2">
-            <AlertTriangle className="h-5 w-5" />
-            {t("mypage.dangerZone.title")}
-          </CardTitle>
-          <CardDescription>{t("mypage.dangerZone.deleteWarning")}</CardDescription>
-        </CardHeader>
-        <CardContent>
+      {/* Delete Account Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent className="sm:max-w-[500px]">
+          <DialogHeader>
+            <DialogTitle className="text-destructive flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5" />
+              {t("mypage.dangerZone.title")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("mypage.dangerZone.deleteWarning")}
+            </DialogDescription>
+          </DialogHeader>
           <DeleteAccountForm userEmail={user.email || ""} />
-        </CardContent>
-      </Card>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/app/(profile)/mypage/page.tsx
+++ b/app/(profile)/mypage/page.tsx
@@ -3,7 +3,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle } from "lucide-react";
 import { getUserProfile } from "@/app/actions/account-actions";
 import { getCurrentSubscription, getCurrentMonthUsage } from "@/app/actions/subscription-actions";
-import { MyPageContent } from "./_components/mypage-content";
+import { MyPageContent } from "./components/mypage-content";
 
 // Force dynamic rendering since this page requires authentication
 export const dynamic = 'force-dynamic';


### PR DESCRIPTION
Refactor account deletion flow to consistently use the service role
(supabase service client) for operations that require bypassing RLS or
administrative privileges. This avoids permission errors and ensures
referential cleanup completes reliably.

- Update imports and component path: move mypage-content to components
  (fix relative path).
- Replace several supabase.delete calls with serviceSupabase for:
  signatures, documents, subscriptions, monthly_usage, customers,
  users profile and other DB deletes so these actions bypass RLS.
- Add explicit step to clear users.current_subscription_id to break a
  circular

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 계정 삭제를 카드 섹션 대신 확인 모달로 진행하도록 변경(경고 아이콘/제목/설명 포함). 버튼 클릭 시 모달이 열리고 폼이 모달 내에서 동작.
- 버그 수정
  - 계정 삭제 절차의 안정성과 일관성 개선으로 관련 데이터 정리 신뢰도 향상.
- 리팩터
  - 삭제 완료 후 서버 리다이렉트 대신 클라이언트 내비게이션으로 즉시 홈으로 이동하며 토스트 알림 표시.
  - 마이페이지 컴포넌트 경로 정리(동작 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->