### PR TITLE
✨ feat(subscriptions): check ends_at when fetching subs

### DIFF
--- a/app/actions/subscription-actions.ts
+++ b/app/actions/subscription-actions.ts
@@ -71,6 +71,9 @@ export async function getCurrentSubscription(): Promise<{
     // Get user's current subscription with plan details
     // Note: We don't filter by plan.is_active because users may have
     // subscriptions to hidden/inactive plans (e.g., Enterprise)
+    // IMPORTANT: Also check ends_at to handle expired subscriptions
+    // even if webhook hasn't updated status yet
+    const now = new Date().toISOString();
     const { data: subscription, error } = await supabase
       .from("subscriptions")
       .select(
@@ -81,6 +84,7 @@ export async function getCurrentSubscription(): Promise<{
       )
       .eq("user_id", user.id)
       .eq("status", "active")
+      .or(`ends_at.is.null,ends_at.gt.${now}`)
       .single();
 
     if (error) {


### PR DESCRIPTION
Include ends_at timestamp in subscription query to avoid returning
expired subscriptions that still have an "active" status due to
delayed webhook updates. Add current time variable and OR filter
for ends_at null or ends_at greater than now to more accurately
reflect whether a subscription is still valid.

This prevents treating expired accounts as active until external
status updates arrive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 만료된 구독이 활성 상태로 잘못 인식되던 문제를 수정했습니다. 이제 종료일이 비어 있거나 현재 시각 이후인 경우에만 활성 구독으로 간주됩니다. 이에 따라 구독 상태 표시, 기능 접근 제어, 배지 표기 등이 정확해졌으며, 결제 갱신이 지연되거나 취소된 계정은 즉시 만료로 반영됩니다. 사용자는 자신의 유효 구독 상태를 일관되게 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->