### PR TITLE
✨ fix: use finalStatus in webhook subscription logs

### DIFF
--- a/lib/paddle/process-webhook.ts
+++ b/lib/paddle/process-webhook.ts
@@ -223,11 +223,11 @@ export class ProcessWebhook {
         }
 
         console.log(
-          `Updated user ${customerData.user_id} subscription to ${planName} (${subscriptionStatus})`
+          `Updated user ${customerData.user_id} subscription to ${planName} (${finalStatus})`
         );
       } else {
         console.log(
-          `Created subscription ${subscriptionId} for ${planName} (${subscriptionStatus}) - waiting for transaction.completed to link to user`
+          `Created subscription ${subscriptionId} for ${planName} (${finalStatus}) - waiting for transaction.completed to link to user`
         );
       }
     } catch (error) {


### PR DESCRIPTION
Update log messages in process-webhook to consistently reference
finalStatus instead of subscriptionStatus. This ensures the console
output reflects the computed final state of a subscription after
processing, avoiding potential confusion when the temporary or
incoming subscriptionStatus differs from the resolved finalStatus.

The change covers both the "updated user" and "created subscription"
log paths so monitoring and debugging rely on the same authoritative
status value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 참고
  * 런타임 로그 메시지를 정리하여 구독 관련 이벤트 기록의 가독성을 개선했습니다. 구독 갱신 및 생성 로그에서 상태 표기를 일관되게 업데이트하고, 처리 대기 상황을 명확히 드러내도록 문구를 다듬었습니다. 이로 인해 운영 모니터링과 진단 시 로그 해석이 쉬워집니다. 배포 후 사용자 경험에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->