### PR TITLE
✨ feat(subscriptions): add refresh callback cancel and consolidate fetching

### DIFF
--- a/components/bills/subscription-detail.tsx
+++ b/components/bills/subscription-detail.tsx
@@ -29,9 +29,10 @@ import { formatDateByLang } from "@/lib/date/format";
 
 interface Props {
   subscriptionId: string;
+  onCancelSuccess?: () => void | Promise<void>;
 }
 
-export function SubscriptionDetail({ subscriptionId }: Props) {
+export function SubscriptionDetail({ subscriptionId, onCancelSuccess }: Props) {
   const { t, language } = useLanguage();
   const [loading, setLoading] = useState(true);
   const [subscription, setSubscription] = useState<Subscription | null>(null);
@@ -124,6 +125,8 @@ export function SubscriptionDetail({ subscriptionId }: Props) {
       // Refresh subscription details
       const fresh = await getSubscription(subscriptionId);
       if (fresh.data) setSubscription(fresh.data);
+      // Notify parent to refresh all data
+      if (onCancelSuccess) await onCancelSuccess();
     } catch (err: any) {
       toast({ title: t("bills.cancel.failed"), description: err?.message });
     } finally {

--- a/components/bills/subscriptions-tab.tsx
+++ b/components/bills/subscriptions-tab.tsx
@@ -21,33 +21,37 @@ export function SubscriptionsTab() {
   const [error, setError] = useState<string | null>(null);
   const [txError, setTxError] = useState<string | null>(null);
 
+  async function fetchSubscriptions() {
+    try {
+      const { data, error: fetchError } = await getSubscriptions();
+
+      if (fetchError) {
+        setError(fetchError);
+      } else {
+        setSubscriptions(data || []);
+      }
+    } catch (err) {
+      console.error("Error:", err);
+      setError(t("bills.error.loadSubscriptions"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function fetchTransactions() {
+    try {
+      const { data } = await getTransactions("", "");
+      setTransactions(data || []);
+    } catch (err) {
+      console.error("Error fetching transactions:", err);
+    }
+  }
+
+  async function refetchData() {
+    await Promise.all([fetchSubscriptions(), fetchTransactions()]);
+  }
+
   useEffect(() => {
-    async function fetchSubscriptions() {
-      try {
-        const { data, error: fetchError } = await getSubscriptions();
-
-        if (fetchError) {
-          setError(fetchError);
-        } else {
-          setSubscriptions(data || []);
-        }
-      } catch (err) {
-        console.error("Error:", err);
-        setError(t("bills.error.loadSubscriptions"));
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    async function fetchTransactions() {
-      try {
-        const { data } = await getTransactions("", "");
-        setTransactions(data || []);
-      } catch (err) {
-        console.error("Error fetching transactions:", err);
-      }
-    }
-
     fetchSubscriptions();
     fetchTransactions();
   }, []);
@@ -76,7 +80,7 @@ export function SubscriptionsTab() {
 
   return (
     <div className="space-y-6">
-      <SubscriptionDetail subscriptionId={subscriptions[0].id} />
+      <SubscriptionDetail subscriptionId={subscriptions[0].id} onCancelSuccess={refetchData} />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 auto-rows-fr items-stretch">
         <div className="h-full">
           <PaymentMethodCard transactions={transactions} subscription={subscriptions[0]} />


### PR DESCRIPTION
Add optional onCancelSuccess prop to SubscriptionDetail and call it
  after a successful cancel so parent components can refresh dependent data.
- Thread onCancelSuccess from SubscriptionsTab into SubscriptionDetail so
  the tab refetches subscriptions and transactions when a cancellation occurs.
- Extract fetchSubscriptions and fetchTransactions into named async
  functions and add refetchData that runs both in parallel via Promise.all.
- Move initial fetch calls into a useEffect that invokes the new helpers,
  improving clarity and enabling reuse for subsequent refreshes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #102 
- <kbd>&nbsp;1&nbsp;</kbd> #101 👈 
<!-- GitButler Footer Boundary Bottom -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 구독 취소 완료 시 구독 목록과 거래 내역이 자동으로 새로고침되어 최신 상태를 즉시 반영합니다.
  * 초기 로딩 동작은 그대로 유지되며, 취소 이후 별도 새로고침 없이도 변경사항을 확인할 수 있습니다.
  * 로딩/오류 표시 동작은 기존과 동일하여 사용자 흐름을 방해하지 않습니다.
  * 다중 구독을 관리할 때도 최신 데이터가 동기화되어 일관된 화면을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->