### PR TITLE
✨ feat(mage): use Basic plan fallback for usage limits

### DIFF
--- a/app/(profile)/mypage/components/mypage-content.tsx
+++ b/app/(profile)/mypage/components/mypage-content.tsx
@@ -38,9 +38,13 @@ interface MyPageContentProps {
     documents_created: number;
     published_completed_count: number;
   } | null;
+  basicPlan: {
+    monthly_document_limit: number;
+    active_document_limit: number;
+  } | null;
 }
 
-export function MyPageContent({ user, profile, subscription, usage }: MyPageContentProps) {
+export function MyPageContent({ user, profile, subscription, usage, basicPlan }: MyPageContentProps) {
   const { t, language } = useLanguage();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
@@ -55,9 +59,9 @@ export function MyPageContent({ user, profile, subscription, usage }: MyPageCont
     ? new Date(profile.created_at).toLocaleDateString(locale)
     : "N/A";
 
-  // Usage calculations
-  const monthlyLimit = subscription?.plan?.monthly_document_limit || 3;
-  const activeLimit = subscription?.plan?.active_document_limit || 3;
+  // Usage calculations - use actual Basic plan from DB as fallback
+  const monthlyLimit = subscription?.plan?.monthly_document_limit || basicPlan?.monthly_document_limit || 0;
+  const activeLimit = subscription?.plan?.active_document_limit || basicPlan?.active_document_limit || 0;
   const documentsCreated = usage?.documents_created || 0;
   const publishedCompleted = usage?.published_completed_count || 0;
   const monthlyProgress = monthlyLimit === -1 ? 0 : (documentsCreated / monthlyLimit) * 100;

--- a/app/(profile)/mypage/page.tsx
+++ b/app/(profile)/mypage/page.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle } from "lucide-react";
 import { getUserProfile } from "@/app/actions/account-actions";
-import { getCurrentSubscription, getCurrentMonthUsage } from "@/app/actions/subscription-actions";
+import { getCurrentSubscription, getCurrentMonthUsage, getBasicPlan } from "@/app/actions/subscription-actions";
 import { MyPageContent } from "./components/mypage-content";
 
 // Force dynamic rendering since this page requires authentication
@@ -14,10 +14,12 @@ export default async function MyPage() {
     { user, profile, error: profileError },
     { subscription },
     { usage },
+    { plan: basicPlan },
   ] = await Promise.all([
     getUserProfile(),
     getCurrentSubscription(),
     getCurrentMonthUsage(),
+    getBasicPlan(),
   ]);
 
   // Redirect if not authenticated
@@ -43,6 +45,7 @@ export default async function MyPage() {
       profile={profile}
       subscription={subscription}
       usage={usage}
+      basicPlan={basicPlan}
     />
   );
 }


### PR DESCRIPTION
Add retrieval of the Basic (free) subscription plan and pass it into
MyPageContent so usage calculations fall back to real plan limits when a
user has no active subscription.

- Add getBasicPlan() in subscription-actions to fetch the lowest-order
  active plan (monthly/active document limits) with error handling.
- Extend MyPageContentProps and MyPageContent to accept basicPlan.
- Use basicPlan values as fallback for monthly and active document
  limits instead of hardcoded defaults.
- Wire getBasicPlan() into the mypage page and pass the returned plan
  through to the component.

This ensures usage progress reflects actual free-tier limits and avoids
incorrect or misleading fallbacks.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #102 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #101 
<!-- GitButler Footer Boundary Bottom -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 마이페이지에서 구독이 없거나 플랜 정보가 비어있는 경우에도 기본 요금제 한도(월간 문서 생성량, 활성 문서 한도)를 자동 적용해 사용량/한도를 안정적으로 표시합니다.
  - 진행률 및 사용량 계산이 기본 한도를 기준으로 동작하여 정보 누락 없이 일관된 지표를 제공합니다.
  - 예외 상황에서는 0을 최종 안전값으로 처리해 잘못된 표시를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->