### PR TITLE
✨ feat: show only active subscriptions in UI

### DIFF
--- a/components/bills/subscriptions-tab.tsx
+++ b/components/bills/subscriptions-tab.tsx
@@ -71,19 +71,25 @@ export function SubscriptionsTab() {
     );
   }
 
-  if (subscriptions.length === 0) {
+  // Filter only active subscriptions (active or trialing)
+  // Canceled/past_due subscriptions should not be shown
+  const activeSubscriptions = subscriptions.filter(
+    (sub) => sub.status === "active" || sub.status === "trialing"
+  );
+
+  if (activeSubscriptions.length === 0) {
     return <NoSubscriptionView />;
   }
 
-  // For now, show only the first subscription
-  const isCanceling = subscriptions[0]?.scheduledChange?.action === "cancel";
+  // For now, show only the first active subscription
+  const isCanceling = activeSubscriptions[0]?.scheduledChange?.action === "cancel";
 
   return (
     <div className="space-y-6">
-      <SubscriptionDetail subscriptionId={subscriptions[0].id} onCancelSuccess={refetchData} />
+      <SubscriptionDetail subscriptionId={activeSubscriptions[0].id} onCancelSuccess={refetchData} />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 auto-rows-fr items-stretch">
         <div className="h-full">
-          <PaymentMethodCard transactions={transactions} subscription={subscriptions[0]} />
+          <PaymentMethodCard transactions={transactions} subscription={activeSubscriptions[0]} />
         </div>
         <div className="h-full">
           {txError ? (


### PR DESCRIPTION
Filter out canceled or past_due subscriptions and render only
subscriptions with statusactive" or "trialing". This ensures the
subscriptions tab displays meaningful, current subscriptions and hides
canceled/expired entries.

Update component logic to:
- create activeSubscriptions by filtering the original list
- return NoSubscriptionView when no active subscriptions exist
- use the first active subscription for SubscriptionDetail and
  PaymentMethodCard
- update isCanceling check to reference the active subscription

This prevents showing irrelevant canceled/past_due subscriptions and
keeps the UI consistent with active billing state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 구독 탭에서 해지/미납 등 비활성 구독이 노출되던 문제를 수정하고, 활성 또는 체험 중인 구독만 표시합니다.
  - 활성 구독이 없을 때 전용 빈 상태 화면을 보여줍니다.
  - 취소 진행 여부가 활성 구독 기준으로 정확히 반영됩니다.
- Refactor
  - 상태, 상세, 결제수단 등 구독 관련 UI가 첫 번째 활성 구독을 일관되게 참조하도록 표시 로직을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->