### PR TITLE
✨ feat: add files and centralize route config

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,18 @@
+import { MetadataRoute } from "next";
+
+/**
+ * Generate robots.txt for SEO
+ * Allows all pages for crawling - actual access control handled by middleware
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/metadata/robots
+ */
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL!;
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,17 @@
+import { MetadataRoute } from "next";
+import { sitemapRoutes } from "@/lib/constants/routes";
+
+/**
+ * Generate sitemap for public pages
+ * @see https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap
+ */
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL!;
+
+  return sitemapRoutes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: route === "/" ? 1.0 : 0.8,
+  }));
+}

--- a/lib/constants/routes.ts
+++ b/lib/constants/routes.ts
@@ -1,0 +1,86 @@
+/**
+ * Route configuration constants
+ * Used for middleware authentication and sitemap generation
+ */
+
+interface Routes {
+  [key: string]: boolean;
+}
+
+/**
+ * Public routes accessible without authentication
+ */
+export const publicRoutes: Routes = {
+  "/login": true,
+  "/register": true,
+  "/register/success": true,
+  "/auth": true,
+  "/error": true,
+  "/": true,
+  "/forgot-password": true,
+  "/reset-password": true,
+  "/privacy": true,
+  "/term": true,
+  "/contact": true,
+};
+
+/**
+ * Routes that should redirect to dashboard if user is authenticated
+ */
+export const publicOnlyRoutes: Routes = {
+  "/login": true,
+  "/register": true,
+  "/register/success": true,
+  "/": true,
+};
+
+/**
+ * Protected routes that require authentication
+ */
+export const protectedRoutes: Routes = {
+  "/upload": true,
+  "/document": true,
+  "/pricing": true,
+};
+
+/**
+ * Static public routes for sitemap generation
+ * Excludes dynamic routes and auth callback routes
+ */
+export const sitemapRoutes = [
+  "/",
+  "/login",
+  "/register",
+  "/privacy",
+  "/term",
+  "/contact",
+  "/forgot-password",
+] as const;
+
+/**
+ * Check if a path is a public route
+ */
+export function isPublicRoute(pathname: string): boolean {
+  // Check explicit public routes
+  if (publicRoutes[pathname]) return true;
+
+  // Check if it's a sign route (public for external users)
+  if (pathname.startsWith("/sign/")) return true;
+
+  // Check if it's an auth route (including auth/confirm, auth/callback, etc.)
+  if (pathname.startsWith("/auth/")) return true;
+
+  return false;
+}
+
+/**
+ * Check if a path is a protected route
+ */
+export function isProtectedRoute(pathname: string): boolean {
+  // Check if the path starts with any protected route pattern
+  return (
+    Object.keys(protectedRoutes).some(
+      (route) => pathname.startsWith(route) || pathname === route
+    ) || pathname.startsWith("/document/")
+  );
+}

--- a/lib/supabase/middleware.ts
+++ b/lib/supabase/middleware.ts
@@ -1,61 +1,6 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
-
-interface Routes {
-  [key: string]: boolean;
-}
-const publicRoutes: Routes = {
-  "/login": true,
-  "/register": true,
-  "/register/success": true,
-  "/auth": true,
-  "/error": true,
-  "/": true,
-  "/forgot-password": true,
-  "/reset-password": true,
-  "/privacy": true,
-  "/term": true,
-  "/contact": true,
-};
-
-// Routes that should redirect to dashboard if user is authenticated
-const publicOnlyRoutes: Routes = {
-  "/login": true,
-  "/register": true,
-  "/register/success": true,
-  "/": true,
-};
-
-// Function to check if a path is public
-function isPublicRoute(pathname: string): boolean {
-  // Check explicit public routes
-  if (publicRoutes[pathname]) return true;
-
-  // Check if it's a sign route (public for external users)
-  if (pathname.startsWith("/sign/")) return true;
-
-  // Check if it's an auth route (including auth/confirm, auth/callback, etc.)
-  if (pathname.startsWith("/auth/")) return true;
-
-  return false;
-}
-
-// Protected routes that require authentication
-const protectedRoutes: Routes = {
-  "/upload": true,
-  "/document": true,
-  "/pricing": true,
-};
-
-// Function to check if a path is protected
-function isProtectedRoute(pathname: string): boolean {
-  // Check if the path starts with any protected route pattern
-  return (
-    Object.keys(protectedRoutes).some(
-      (route) => pathname.startsWith(route) || pathname === route
-    ) || pathname.startsWith("/document/")
-  );
-}
+import { publicOnlyRoutes, isPublicRoute } from "@/lib/constants/routes";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,9 +12,11 @@ export const config = {
      * - _next/static (static files)
      * - _next/image (image optimization files)
      * - favicon.ico (favicon file)
+     * - sitemap.xml (SEO sitemap)
+     * - robots.txt (SEO robots)
      * - .*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$ (image files)
      * - api/webhook (Paddle webhook endpoint)
      */
-    "/((?!_next/static|_next/image|favicon.ico|api/webhook|.*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|api/webhook|.*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
Add robots.txt and sitemap metadata routes and extract route
configuration into lib/constants/routes.ts to centralize public,
public-only, and protected route logic. Move route-checking helpers
(isPublicRoute, isProtectedRoute) out of Supabase middleware and
import the shared functions there to avoid duplication and ensure a
single source of truth for auth-related route rules.

Update middleware patterns to allow sitemap.xml and robots.txt to be
served directly (exclude them from auth/middleware handling) and
document excluded static paths. These changes improve SEO support
(sitemap/robots) and simplify maintenance of route access rules for
authentication and sitemap generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 자동 생성된 sitemap.xml과 robots.txt 제공으로 검색 엔진 색인 및 크롤링 호환성 향상
- 버그 수정
  - 없음
- 리팩터링
  - 라우트 접근 규칙을 중앙화하여 인증/비인증 경로 판별의 일관성 및 유지보수성 개선
- 작업(Chores)
  - 미들웨어 매처를 조정해 sitemap.xml, robots.txt를 인증 흐름에서 제외, 공개적으로 안정적으로 제공되도록 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->