### PR TITLE
✨ feat(i18n): add document & publish strings and use i18n in UI

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -154,7 +154,7 @@ export default function DocumentDetailComponent({
       router.refresh();
     } catch (error) {
       console.error("Error updating signature areas:", error);
-      setError("서명 영역 업데이트 중 오류가 발생했습니다");
+      setError(t("documentDetail.errorUpdateArea"));
     } finally {
       setIsLoading(false);
     }
@@ -170,7 +170,7 @@ export default function DocumentDetailComponent({
       window.open(signedDocumentUrl, '_blank');
     } catch (error) {
       console.error('Download failed:', error);
-      setError('다운로드 중 오류가 발생했습니다.');
+      setError(t("documentDetail.errorDownload"));
     }
   };
 
@@ -197,7 +197,7 @@ export default function DocumentDetailComponent({
       }
     } catch (error) {
       console.error("❌ Error deleting document:", error);
-      setError("문서 삭제 중 오류가 발생했습니다");
+      setError(t("documentDetail.errorDelete"));
     } finally {
       setIsLoading(false);
       setIsDeleteModalOpen(false);
@@ -400,7 +400,7 @@ export default function DocumentDetailComponent({
                           className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
                         >
                           <Edit className="mr-1 h-3 w-3" />
-                          수정
+                          {t("documentDetail.edit")}
                         </Button>
                         <Button
                           variant="destructive"
@@ -409,7 +409,7 @@ export default function DocumentDetailComponent({
                           className="h-9 px-3 text-sm font-medium"
                         >
                           <Trash2 className="mr-1 h-3 w-3" />
-                          삭제
+                          {t("documentDetail.delete")}
                         </Button>
                       </div>
                     </div>
@@ -424,7 +424,7 @@ export default function DocumentDetailComponent({
                         className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
                       >
                         <Download className="mr-1 h-3 w-3" />
-                        다운로드
+                        {t("documentDetail.download")}
                       </Button>
                     </div>
                   )}
@@ -442,7 +442,7 @@ export default function DocumentDetailComponent({
                         className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
                       >
                         <Edit className="mr-1 h-3 w-3" />
-                        취소
+                        {t("documentDetail.cancel")}
                       </Button>
                       <Button
                         onClick={handleAddSignatureArea}
@@ -450,7 +450,7 @@ export default function DocumentDetailComponent({
                         className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
                         variant="outline"
                       >
-                        영역추가
+                        {t("documentDetail.addArea")}
                       </Button>
                     </div>
                     {/* Right Group - Save */}
@@ -459,7 +459,7 @@ export default function DocumentDetailComponent({
                       disabled={isLoading}
                       className="h-9 px-3 text-sm font-medium bg-green-600 hover:bg-green-700"
                     >
-                      {isLoading ? "저장중" : "저장"}
+                      {isLoading ? t("documentDetail.saving") : t("documentDetail.save")}
                     </Button>
                   </div>
                 </>
@@ -482,7 +482,7 @@ export default function DocumentDetailComponent({
                           className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
                         >
                           <Edit className="mr-2 h-4 w-4" />
-                          수정
+                          {t("documentDetail.edit")}
                         </Button>
                         <Button
                           variant="destructive"
@@ -491,7 +491,7 @@ export default function DocumentDetailComponent({
                           className="h-10 px-4 text-sm font-medium"
                         >
                           <Trash2 className="mr-2 h-4 w-4" />
-                          삭제
+                          {t("documentDetail.delete")}
                         </Button>
                       </div>
                     </div>
@@ -506,7 +506,7 @@ export default function DocumentDetailComponent({
                         className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
                       >
                         <Download className="mr-2 h-4 w-4" />
-                        다운로드
+                        {t("documentDetail.download")}
                       </Button>
                     </div>
                   )}
@@ -524,7 +524,7 @@ export default function DocumentDetailComponent({
                         className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
                       >
                         <Edit className="mr-2 h-4 w-4" />
-                        취소
+                        {t("documentDetail.cancel")}
                       </Button>
                       <Button
                         onClick={handleAddSignatureArea}
@@ -532,7 +532,7 @@ export default function DocumentDetailComponent({
                         className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
                         variant="outline"
                       >
-                        영역추가
+                        {t("documentDetail.addArea")}
                       </Button>
                     </div>
                     {/* Right Group - Save */}
@@ -541,7 +541,7 @@ export default function DocumentDetailComponent({
                       disabled={isLoading}
                       className="h-10 px-4 text-sm font-medium bg-green-600 hover:bg-green-700"
                     >
-                      {isLoading ? "저장중" : "저장"}
+                      {isLoading ? t("documentDetail.saving") : t("documentDetail.save")}
                     </Button>
                   </div>
                 </>
@@ -634,7 +634,7 @@ export default function DocumentDetailComponent({
               >
                 {!displayImageUrl ? (
                   <div className="w-full h-96 flex items-center justify-center bg-gray-100">
-                    <p className="text-gray-500">문서 로딩 중...</p>
+                    <p className="text-gray-500">{t("documentDetail.loading")}</p>
                   </div>
                 ) : (
                   <img
@@ -690,7 +690,7 @@ export default function DocumentDetailComponent({
                           isEditMode ? "text-red-600" : "text-blue-600"
                         }`}
                       >
-                        <span className="hidden sm:inline">서명 영역 {index + 1}</span>
+                        <span className="hidden sm:inline">{t("documentDetail.signatureArea")} {index + 1}</span>
                         <span className="sm:hidden">{index + 1}</span>
                       </span>
                     )}

--- a/app/(document)/publish/components/PublishPageContent.tsx
+++ b/app/(document)/publish/components/PublishPageContent.tsx
@@ -3,19 +3,22 @@
 import { ProjectBreadcrumb } from "@/components/breadcrumb";
 import PublishForm from "@/components/publish/publish-form";
 import type { Document } from "@/lib/supabase/database.types";
+import { useLanguage } from "@/contexts/language-context";
 
 interface PublishPageContentProps {
   documents: Document[];
 }
 
 export default function PublishPageContent({ documents }: PublishPageContentProps) {
+  const { t } = useLanguage();
+
   return (
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-2xl mx-auto">
         {/* Breadcrumb */}
         <ProjectBreadcrumb />
 
-        <h1 className="text-2xl font-bold mb-6">문서 발행</h1>
+        <h1 className="text-2xl font-bold mb-6">{t("publish.title")}</h1>
         <PublishForm documents={documents} />
       </div>
     </div>

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -302,7 +302,7 @@ export default function DocumentUpload() {
                 signatureAreas.length === 0 || isLoading || !originalFile
               }
             >
-              {isLoading ? "저장 중..." : "저장하기"}
+              {isLoading ? t("upload.saving") : t("upload.save")}
             </Button>
           </div>
 

--- a/components/publish/publish-form.tsx
+++ b/components/publish/publish-form.tsx
@@ -17,12 +17,14 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { CalendarIcon } from "lucide-react";
+import { useLanguage } from "@/contexts/language-context";
 
 interface PublishFormProps {
   documents: Document[];
 }
 
 export default function PublishForm({ documents }: PublishFormProps) {
+  const { t, language } = useLanguage();
   const router = useRouter();
   const [selectedDocuments, setSelectedDocuments] = useState<string[]>([]);
   const [publicationName, setPublicationName] = useState("");
@@ -53,22 +55,22 @@ export default function PublishForm({ documents }: PublishFormProps) {
     setError("");
 
     if (!publicationName.trim()) {
-      setError("발행 이름을 입력해주세요.");
+      setError(t("publish.errorName"));
       return;
     }
 
     if (!password.trim()) {
-      setError("비밀번호를 입력해주세요.");
+      setError(t("publish.errorPassword"));
       return;
     }
 
     if (!expiresAt) {
-      setError("만료일을 선택해주세요.");
+      setError(t("publish.errorExpiration"));
       return;
     }
 
     if (selectedDocuments.length === 0) {
-      setError("최소 1개 이상의 문서를 선택해주세요.");
+      setError(t("publish.errorDocuments"));
       return;
     }
 
@@ -93,7 +95,7 @@ export default function PublishForm({ documents }: PublishFormProps) {
         router.push(`/publication/${result.shortUrl}`);
       }
     } catch (err) {
-      setError("발행 중 오류가 발생했습니다.");
+      setError(t("publish.errorPublishing"));
       setIsLoading(false);
     }
   };
@@ -111,32 +113,32 @@ export default function PublishForm({ documents }: PublishFormProps) {
       )}
 
       <div className="space-y-2">
-        <Label htmlFor="publicationName">발행 이름</Label>
+        <Label htmlFor="publicationName">{t("publish.name")}</Label>
         <Input
           id="publicationName"
           type="text"
           value={publicationName}
           onChange={(e) => setPublicationName(e.target.value)}
-          placeholder="예: 2024년 1분기 계약서"
+          placeholder={t("publish.namePlaceholder")}
           required
         />
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="password">비밀번호</Label>
+        <Label htmlFor="password">{t("publish.password")}</Label>
         <Input
           id="password"
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          placeholder="서명 페이지 접근 시 필요한 비밀번호"
+          placeholder={t("publish.passwordPlaceholder")}
           required
         />
       </div>
 
       {/* Date Picker with Popover + Calendar (from original modal) */}
       <div className="space-y-2">
-        <Label>만료일</Label>
+        <Label>{t("publish.expiration")}</Label>
         <Popover open={isCalendarOpen} onOpenChange={setIsCalendarOpen}>
           <PopoverTrigger asChild>
             <Button
@@ -150,12 +152,15 @@ export default function PublishForm({ documents }: PublishFormProps) {
             >
               <CalendarIcon className="mr-2 h-4 w-4" />
               {expiresAt
-                ? expiresAt.toLocaleDateString("ko-KR", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })
-                : "서명 만료 날짜를 선택하세요"}
+                ? expiresAt.toLocaleDateString(
+                    language === "ko" ? "ko-KR" : "en-US",
+                    {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric",
+                    }
+                  )
+                : t("publish.expirationPlaceholder")}
             </Button>
           </PopoverTrigger>
           <PopoverContent className="w-auto p-0" align="start">
@@ -177,20 +182,20 @@ export default function PublishForm({ documents }: PublishFormProps) {
           </PopoverContent>
         </Popover>
         <p className="text-xs text-gray-500">
-          이 날짜까지 서명자가 문서에 접근할 수 있습니다.
+          {t("publish.expirationHint")}
         </p>
       </div>
 
       <div className="space-y-4">
         <div className="flex items-center justify-between">
-          <Label>문서 선택 ({selectedDocuments.length}/{documents.length})</Label>
+          <Label>{t("publish.documentSelection")} ({selectedDocuments.length}/{documents.length})</Label>
           <Button
             type="button"
             variant="outline"
             size="sm"
             onClick={handleSelectAll}
           >
-            {selectedDocuments.length === documents.length ? "전체 해제" : "전체 선택"}
+            {selectedDocuments.length === documents.length ? t("publish.deselectAll") : t("publish.selectAll")}
           </Button>
         </div>
 
@@ -217,7 +222,9 @@ export default function PublishForm({ documents }: PublishFormProps) {
                   <div className="flex-1">
                     <p className="font-medium">{document.filename}</p>
                     <p className="text-sm text-muted-foreground">
-                      {new Date(document.created_at).toLocaleDateString("ko-KR")}
+                      {new Date(document.created_at).toLocaleDateString(
+                        language === "ko" ? "ko-KR" : "en-US"
+                      )}
                     </p>
                   </div>
                 </Label>
@@ -234,10 +241,10 @@ export default function PublishForm({ documents }: PublishFormProps) {
           onClick={() => router.back()}
           disabled={isLoading}
         >
-          취소
+          {t("publish.cancel")}
         </Button>
         <Button type="submit" disabled={isLoading} className="flex-1">
-          {isLoading ? "발행 중..." : "발행하기"}
+          {isLoading ? t("publish.submitting") : t("publish.submit")}
         </Button>
       </div>
     </form>

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -44,6 +44,8 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.getSignature": "서명 받기",
     "upload.generating": "생성 중...",
     "upload.signature": "서명",
+    "upload.save": "저장하기",
+    "upload.saving": "저장 중...",
 
     // Sign Page
     "sign.loading": "문서 로딩 중...",
@@ -477,6 +479,41 @@ const translations: Record<Language, Record<string, string>> = {
     "publicationDetail.save": "저장",
     "publicationDetail.saving": "저장 중...",
     "publicationDetail.cannotEditCompleted": "완료된 발행은 수정할 수 없습니다",
+
+    // Document Detail
+    "documentDetail.edit": "수정",
+    "documentDetail.delete": "삭제",
+    "documentDetail.download": "다운로드",
+    "documentDetail.cancel": "취소",
+    "documentDetail.addArea": "영역추가",
+    "documentDetail.save": "저장",
+    "documentDetail.saving": "저장중",
+    "documentDetail.loading": "문서 로딩 중...",
+    "documentDetail.signatureArea": "서명 영역",
+    "documentDetail.errorUpdateArea": "서명 영역 업데이트 중 오류가 발생했습니다",
+    "documentDetail.errorDownload": "다운로드 중 오류가 발생했습니다.",
+    "documentDetail.errorDelete": "문서 삭제 중 오류가 발생했습니다",
+
+    // Publish Page
+    "publish.title": "문서 발행",
+    "publish.errorName": "발행 이름을 입력해주세요.",
+    "publish.errorPassword": "비밀번호를 입력해주세요.",
+    "publish.errorExpiration": "만료일을 선택해주세요.",
+    "publish.errorDocuments": "최소 1개 이상의 문서를 선택해주세요.",
+    "publish.errorPublishing": "발행 중 오류가 발생했습니다.",
+    "publish.name": "발행 이름",
+    "publish.namePlaceholder": "예: 2024년 1분기 계약서",
+    "publish.password": "비밀번호",
+    "publish.passwordPlaceholder": "서명 페이지 접근 시 필요한 비밀번호",
+    "publish.expiration": "만료일",
+    "publish.expirationPlaceholder": "서명 만료 날짜를 선택하세요",
+    "publish.expirationHint": "이 날짜까지 서명자가 문서에 접근할 수 있습니다.",
+    "publish.documentSelection": "문서 선택",
+    "publish.selectAll": "전체 선택",
+    "publish.deselectAll": "전체 해제",
+    "publish.cancel": "취소",
+    "publish.submit": "발행하기",
+    "publish.submitting": "발행 중...",
 
     // Footer
     "footer.terms": "이용약관",
@@ -993,6 +1030,8 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.getSignature": "Get Signature",
     "upload.generating": "Generating...",
     "upload.signature": "Signature",
+    "upload.save": "Save",
+    "upload.saving": "Saving...",
 
     // Sign Page
     "sign.loading": "Loading document...",
@@ -1431,6 +1470,41 @@ const translations: Record<Language, Record<string, string>> = {
     "publicationDetail.save": "Save",
     "publicationDetail.saving": "Saving...",
     "publicationDetail.cannotEditCompleted": "Cannot edit completed publications",
+
+    // Document Detail
+    "documentDetail.edit": "Edit",
+    "documentDetail.delete": "Delete",
+    "documentDetail.download": "Download",
+    "documentDetail.cancel": "Cancel",
+    "documentDetail.addArea": "Add Area",
+    "documentDetail.save": "Save",
+    "documentDetail.saving": "Saving",
+    "documentDetail.loading": "Loading document...",
+    "documentDetail.signatureArea": "Signature area",
+    "documentDetail.errorUpdateArea": "Failed to update signature area",
+    "documentDetail.errorDownload": "Failed to download document.",
+    "documentDetail.errorDelete": "Failed to delete document",
+
+    // Publish Page
+    "publish.title": "Publish Documents",
+    "publish.errorName": "Please enter a publication name.",
+    "publish.errorPassword": "Please enter a password.",
+    "publish.errorExpiration": "Please select an expiration date.",
+    "publish.errorDocuments": "Please select at least one document.",
+    "publish.errorPublishing": "An error occurred while publishing.",
+    "publish.name": "Publication Name",
+    "publish.namePlaceholder": "e.g., Q1 2024 Contracts",
+    "publish.password": "Password",
+    "publish.passwordPlaceholder": "Required password to access signature page",
+    "publish.expiration": "Expiration Date",
+    "publish.expirationPlaceholder": "Select signature expiration date",
+    "publish.expirationHint": "Signers can access documents until this date.",
+    "publish.documentSelection": "Select Documents",
+    "publish.selectAll": "Select All",
+    "publish.deselectAll": "Deselect All",
+    "publish.cancel": "Cancel",
+    "publish.submit": "Publish",
+    "publish.submitting": "Publishing...",
 
     // Footer
     "footer.terms": "Terms of Service",


### PR DESCRIPTION
Add new localization keys for Document Detail and Publish pages in both
Korean and English language bundles. Keys include actions and status
labels (edit, delete, download, save, saving, loading), error messages
(errorUpdateArea, errorDownload, errorDelete, publish errors), and
publish form fields and placeholders (name, password, expiration,
document selection, submit states).

Replace hardcoded upload save button text with i18n lookup in the
document upload component to use the new upload.save / upload.saving
keys. Hook the language context into PublishPageContent to access the
translation function (t) for consistent localization usage.

Reason: prepare UI strings for document detail and publishing flows and
centralize text via the language context to enable localization and avoid
hardcoded strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 애플리케이션 전체에 다국어 지원 추가
  
* **개선 사항**
  * 문서 상세 페이지, 발행 페이지, 문서 업로드 모듈의 모든 사용자 인터페이스 텍스트(버튼, 레이블, 오류 메시지, 안내 문구)가 한국어 및 영어로 현지화됨
  * 날짜 형식이 선택된 언어에 따라 표시됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->