### PR TITLE
✨feat(sign): refresh on return to list to update signature counts

### DIFF
--- a/app/(sign)/sign/[id]/components/SignPageContainer.tsx
+++ b/app/(sign)/sign/[id]/components/SignPageContainer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import type { PublicationWithDocuments } from "@/lib/supabase/database.types";
 import SignDocumentList from "./SignDocumentList";
 import SignSingleDocument from "./SignSingleDocument";
@@ -23,6 +24,7 @@ export default function SignPageContainer({
   requiresPassword,
 }: SignPageContainerProps) {
   const { t } = useLanguage();
+  const router = useRouter();
   const [currentView, setCurrentView] = useState<View>("list");
   const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(null);
   const [completedDocumentName, setCompletedDocumentName] = useState<string>("");
@@ -34,6 +36,8 @@ export default function SignPageContainer({
   };
 
   const handleBackToList = () => {
+    // Refresh server data to get updated signature counts
+    router.refresh();
     setCurrentView("list");
     setSelectedDocumentId(null);
   };


### PR DESCRIPTION
Add useRouter from next/navigation and call router.refresh() when
navigating back from a document view to the list in SignPageContainer.
This ensures server-derived state (like signature counts) is up to date
after completing a document, preventing stale counts the list view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 서명 페이지에서 목록으로 돌아갈 때 서버의 최신 데이터가 자동으로 새로고침되도록 개선했습니다. 이제 항상 최신 정보가 정확하게 표시되며, 데이터 불일치 문제가 해결되어 더욱 안정적인 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->