### PR TITLE
✨ feat(sign): hide back button on completed publications

### DIFF
--- a/app/(sign)/sign/[id]/components/SignPageContainer.tsx
+++ b/app/(sign)/sign/[id]/components/SignPageContainer.tsx
@@ -49,6 +49,8 @@ export default function SignPageContainer({
   const handleDocumentComplete = (documentName: string) => {
     setCompletedDocumentName(documentName);
     setCurrentView("completed");
+    // Refresh data immediately to get updated publication status
+    router.refresh();
   };
 
   // Show document list view
@@ -130,14 +132,17 @@ export default function SignPageContainer({
                     {t("sign.completed.status")}
                   </p>
                 </div>
-                <Button
-                  variant="outline"
-                  onClick={handleBackToList}
-                  className="w-full"
-                >
-                  <ArrowLeft className="mr-2 h-4 w-4" />
-                  {t("sign.documentList.backToList")}
-                </Button>
+                {/* Hide back button if publication is already completed */}
+                {publicationData.status !== "completed" && (
+                  <Button
+                    variant="outline"
+                    onClick={handleBackToList}
+                    className="w-full"
+                  >
+                    <ArrowLeft className="mr-2 h-4 w-4" />
+                    {t("sign.documentList.backToList")}
+                  </Button>
+                )}
               </CardContent>
             </Card>
           </div>

--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -650,14 +650,17 @@ export default function SignSingleDocument({
         <LanguageSelector />
       </div>
       <div className="max-w-5xl mx-auto">
-        <Button
-          variant="ghost"
-          onClick={onBack}
-          className="mb-4 -ml-2"
-        >
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          {t("sign.documentList.title")}
-        </Button>
+        {/* Hide back button if publication is already completed */}
+        {!isCompleted && (
+          <Button
+            variant="ghost"
+            onClick={onBack}
+            className="mb-4 -ml-2"
+          >
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            {t("sign.documentList.title")}
+          </Button>
+        )}
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-2">{documentData.filename}</h1>
           <p className="text-muted-foreground">{t("sign.clickAreas")}</p>


### PR DESCRIPTION
Refresh publication data immediately after signing and prevent
avigating back to the document list for already-completed
publications.

- Call router.refresh() in SignPageContainer.handleDocumentComplete
  to fetch updated publication status as soon as a document completes.
- Conditionally render the "back to list" button in SignPageContainer
  only when publicationData.status !== "completed".
- Conditionally render the back button in SignSingleDocument only when
  !isCompleted to avoid exposing navigation after completion.

These changes ensure the UI reflects the latest publication state
and prevents returning to the list once a publication is finished.