### PR TITLE
✨ feat(publication): remove debug logging from publication lookup

### DIFF
--- a/app/actions/publication-actions.ts
+++ b/app/actions/publication-actions.ts
@@ -278,8 +278,6 @@ export async function getPublicationByShortUrl(
     // Use service role to bypass RLS for public access
     const supabase = createServiceSupabase();
 
-    console.log("🔍 Looking for publication with short_url:", shortUrl);
-
     const { data: publication, error: pubError } = await supabase
       .from("publications")
       .select(`
@@ -288,8 +286,6 @@ export async function getPublicationByShortUrl(
       `)
       .eq("short_url", shortUrl)
       .single();
-
-    console.log("📦 Publication query result:", { publication, error: pubError });
 
     if (pubError || !publication) {
       console.error("❌ Publication not found:", { shortUrl, error: pubError });
@@ -320,7 +316,6 @@ export async function getPublicationByShortUrl(
           .eq("id", publication.id);
         // Update the publication object with new status
         publication.status = "completed";
-        console.log("✅ Publication status updated to completed:", publication.id);
       }
     }
 


### PR DESCRIPTION
Remove console.debug/log statements that were left the publication
lookup status update flow. These debug logs printed the short,
the full publication result, and a confirmation when status was
updated to "completed".

This cleans up server logs, reduces noise, and avoids leaking potentially
sensitive internal data to stdout in production.