### PR TITLE
✨ feat: allow deleting completed documents & filter deleted pubs

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -175,8 +175,8 @@ export default function DocumentDetailComponent({
   };
 
   const handleDeleteDocument = async () => {
-
-    if (document.status !== "draft") {
+    // Allow deletion for both draft and completed documents
+    if (document.status !== "draft" && document.status !== "completed") {
       return;
     }
 
@@ -205,6 +205,7 @@ export default function DocumentDetailComponent({
   };
 
   const canEdit = document.status === "draft";
+  const canDelete = document.status === "draft" || document.status === "completed";
   const isCompleted = document.status === "completed";
 
   // Set mounted state on client side
@@ -388,7 +389,7 @@ export default function DocumentDetailComponent({
             <div className="sm:hidden">
               {!isEditMode ? (
                 <>
-                  {/* Draft State - Single Line Actions */}
+                  {/* Draft State - Edit and Delete Actions */}
                   {canEdit && (
                     <div className="flex justify-between items-center mb-8">
                       {/* Left Group - Edit & Delete */}
@@ -414,18 +415,29 @@ export default function DocumentDetailComponent({
                       </div>
                     </div>
                   )}
-                  {/* Completed State - Download Button */}
-                  {isCompleted && signedDocumentUrl && (
-                    <div className="flex justify-center mb-8">
+                  {/* Completed State - Download and Delete */}
+                  {isCompleted && (
+                    <div className="flex justify-between items-center mb-8">
                       <Button
                         variant="outline"
                         onClick={handleDownloadSignedDocument}
-                        disabled={isLoading}
+                        disabled={isLoading || !signedDocumentUrl}
                         className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
                       >
                         <Download className="mr-1 h-3 w-3" />
                         {t("documentDetail.download")}
                       </Button>
+                      {canDelete && (
+                        <Button
+                          variant="destructive"
+                          onClick={() => setIsDeleteModalOpen(true)}
+                          disabled={isLoading}
+                          className="h-9 px-3 text-sm font-medium"
+                        >
+                          <Trash2 className="mr-1 h-3 w-3" />
+                          {t("documentDetail.delete")}
+                        </Button>
+                      )}
                     </div>
                   )}
                 </>
@@ -470,7 +482,7 @@ export default function DocumentDetailComponent({
             <div className="hidden sm:block">
               {!isEditMode ? (
                 <>
-                  {/* Draft State - Single Line Actions */}
+                  {/* Draft State - Edit and Delete Actions */}
                   {canEdit && (
                     <div className="flex justify-between items-center mb-8">
                       {/* Left Group - Edit & Delete */}
@@ -496,18 +508,29 @@ export default function DocumentDetailComponent({
                       </div>
                     </div>
                   )}
-                  {/* Completed State - Download Button */}
-                  {isCompleted && signedDocumentUrl && (
-                    <div className="flex justify-center mb-8">
+                  {/* Completed State - Download and Delete */}
+                  {isCompleted && (
+                    <div className="flex justify-between items-center mb-8">
                       <Button
                         variant="outline"
                         onClick={handleDownloadSignedDocument}
-                        disabled={isLoading}
+                        disabled={isLoading || !signedDocumentUrl}
                         className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
                       >
                         <Download className="mr-2 h-4 w-4" />
                         {t("documentDetail.download")}
                       </Button>
+                      {canDelete && (
+                        <Button
+                          variant="destructive"
+                          onClick={() => setIsDeleteModalOpen(true)}
+                          disabled={isLoading}
+                          className="h-10 px-4 text-sm font-medium"
+                        >
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          {t("documentDetail.delete")}
+                        </Button>
+                      )}
                     </div>
                   )}
                 </>

--- a/components/dashboard/publication-card.tsx
+++ b/components/dashboard/publication-card.tsx
@@ -184,9 +184,7 @@ export function PublicationCard({ publication, onDelete }: PublicationCardProps)
               variant="outline"
               size="sm"
               onClick={handleOpenDeleteDialog}
-              disabled={publication.status === "completed"}
               className="h-8 px-2 hover:bg-destructive hover:text-destructive-foreground"
-              title={publication.status === "completed" ? t("dashboard.publications.card.cannotDelete") : undefined}
             >
               <Trash2 className="h-3 w-3" />
             </Button>

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -42,9 +42,11 @@ export type Database = {
         Row: {
           created_at: string
           created_month: string
+          deleted_at: string | null
           file_url: string
           filename: string
           id: string
+          is_deleted: boolean
           publication_id: string | null
           signed_file_url: string | null
           status: string | null
@@ -53,9 +55,11 @@ export type Database = {
         Insert: {
           created_at?: string
           created_month: string
+          deleted_at?: string | null
           file_url: string
           filename: string
           id?: string
+          is_deleted?: boolean
           publication_id?: string | null
           signed_file_url?: string | null
           status?: string | null
@@ -64,9 +68,11 @@ export type Database = {
         Update: {
           created_at?: string
           created_month?: string
+          deleted_at?: string | null
           file_url?: string
           filename?: string
           id?: string
+          is_deleted?: boolean
           publication_id?: string | null
           signed_file_url?: string | null
           status?: string | null
@@ -115,8 +121,10 @@ export type Database = {
       publications: {
         Row: {
           created_at: string | null
+          deleted_at: string | null
           expires_at: string | null
           id: string
+          is_deleted: boolean
           name: string
           password: string | null
           short_url: string
@@ -126,8 +134,10 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
+          deleted_at?: string | null
           expires_at?: string | null
           id?: string
+          is_deleted?: boolean
           name: string
           password?: string | null
           short_url: string
@@ -137,8 +147,10 @@ export type Database = {
         }
         Update: {
           created_at?: string | null
+          deleted_at?: string | null
           expires_at?: string | null
           id?: string
+          is_deleted?: boolean
           name?: string
           password?: string | null
           short_url?: string


### PR DESCRIPTION
Allow deletion of completed documents in the document detail UI and
protect download button when no signed URL exists.

- Permit deletion when document.status is "completed" in the
  handleDeleteDocument guard and expose canDelete (draft or completed).
- Add delete button (destructive) next to download action for completed
  documents on both mobile and desktop layouts, opening the delete modal.
- Disable download button when signedDocumentUrl is missing or while
  loading to prevent erroneous clicks.
- Update comments to clarify Edit/Delete action group wording.

Backend/data fetching change:
- Exclude logically deleted publications from publication queries by
  adding .eq("is_deleted", false) in publication-actions list query.

Misc:
- Fix a small comment typo in publication action that referenced "use".
- Keep existing authorization checks unchanged.

These changes improve UX by enabling users to remove completed
documents and ensure publication lists omit soft-deleted items.