### PR TITLE
✨ feat: add missing list items and remove article 22

### DIFF
--- a/app/(policy)/term/page.tsx
+++ b/app/(policy)/term/page.tsx
@@ -49,6 +49,9 @@ export default function TermPage() {
               <li>{t("term.article2.item4")}</li>
               <li>{t("term.article2.item5")}</li>
               <li>{t("term.article2.item6")}</li>
+              <li>{t("term.article2.item7")}</li>
+              <li>{t("term.article2.item8")}</li>
+              <li>{t("term.article2.item9")}</li>
             </ol>
 
             <h3 className="text-xl font-semibold mb-3">
@@ -147,6 +150,7 @@ export default function TermPage() {
             <ol className="list-decimal pl-6 space-y-2 mb-4">
               <li>{t("term.article11.para1")}</li>
               <li>{t("term.article11.para2")}</li>
+              <li>{t("term.article11.para3")}</li>
             </ol>
 
             <h3 className="text-xl font-semibold mb-3">
@@ -173,6 +177,7 @@ export default function TermPage() {
               <li>{t("term.article14.para1")}</li>
               <li>{t("term.article14.para2")}</li>
               <li>{t("term.article14.para3")}</li>
+              <li>{t("term.article14.para4")}</li>
             </ol>
 
             <h3 className="text-xl font-semibold mb-3">
@@ -263,11 +268,6 @@ export default function TermPage() {
               <li>{t("term.article21.para1")}</li>
               <li>{t("term.article21.para2")}</li>
             </ol>
-
-            <h3 className="text-xl font-semibold mb-3">
-              {t("term.article22.title")}
-            </h3>
-            <p className="mb-4">{t("term.article22.content")}</p>
 
             <h3 className="text-xl font-semibold mb-3">
               {t("term.article23.title")}


### PR DESCRIPTION
Add three new list items to Article 2 (item7–item9) to reflect
expanded terms and ensure the ordered list matches localized content.

Add a missing paragraph to Article 11 (para3) and an extra paragraph
to Article 14 (para4) so those articles present complete clauses.

Remove Article 22 (title and content) from the terms page because it is
no longer applicable in the current policy and would duplicate or
conflict with surrounding articles. Adjust markup to keep proper list
and heading structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 약관 제2조의 목록 항목 3개 추가
  * 약관 제11조에 새로운 단락 추가
  * 약관 제14조에 새로운 단락 추가
  * 약관 제22조 삭제

<!-- end of auto-generated comment: release notes by coderabbit.ai -->