### PR TITLE
✨ feat(upload): add optional document alias and show in UI

### DIFF
--- a/app/(document)/dashboard/page.tsx
+++ b/app/(document)/dashboard/page.tsx
@@ -2,6 +2,10 @@ import { DashboardContent } from "@/components/dashboard/dashboard-content";
 import { DashboardHeader } from "@/components/dashboard/dashboard-header";
 import { ProjectBreadcrumb } from "@/components/breadcrumb";
 
+// Disable caching for this page to always show fresh data
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 export default function DashboardPage() {
   return (
     <div className="container mx-auto px-4 py-8">

--- a/app/(document)/document/[id]/page.tsx
+++ b/app/(document)/document/[id]/page.tsx
@@ -2,6 +2,10 @@ import { notFound } from "next/navigation";
 import { getDocumentById } from "@/app/actions/document-actions";
 import DocumentDetailComponent from "./components/DocumentDetailPage";
 
+// Disable caching for this page to always show fresh data
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 // This is a Server Component that fetches document data
 interface PageProps {
   params: { id: string };

--- a/app/(publication)/publication/[shortUrl]/page.tsx
+++ b/app/(publication)/publication/[shortUrl]/page.tsx
@@ -3,6 +3,10 @@ import { createServerSupabase } from "@/lib/supabase/server";
 import { redirect } from "next/navigation";
 import { PublicationDetailContent } from "@/components/publication/publication-detail-content";
 
+// Disable caching for this page to always show fresh data
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 interface PublicationDetailPageProps {
   params: {
     shortUrl: string;

--- a/app/(sign)/sign/[id]/components/SignDocumentList.tsx
+++ b/app/(sign)/sign/[id]/components/SignDocumentList.tsx
@@ -303,7 +303,7 @@ export default function SignDocumentList({
                       <FileText className="h-8 w-8 text-primary flex-shrink-0" />
                       <div className="flex-1 min-w-0">
                         <h3 className="font-medium text-lg mb-1 truncate">
-                          {document.filename}
+                          {document.alias || document.filename}
                         </h3>
                         <div className="flex items-center gap-2">
                           {isDocumentComplete ? (

--- a/app/(sign)/sign/[id]/components/SignPage.tsx
+++ b/app/(sign)/sign/[id]/components/SignPage.tsx
@@ -619,7 +619,7 @@ export default function SignPageComponent({
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded-md p-3">
                   <p className="text-sm text-green-700 text-center font-medium">
-                    {documentData.filename}
+                    {documentData.alias || documentData.filename}
                   </p>
                   <p className="text-xs text-green-600 text-center mt-1">
                     {t("sign.completed.status")}
@@ -661,7 +661,7 @@ export default function SignPageComponent({
               </div>
               <div className="bg-red-50 border border-red-200 rounded-md p-3">
                 <p className="text-sm text-red-700 text-center font-medium">
-                  {documentData.filename}
+                  {documentData.alias || documentData.filename}
                 </p>
                 {documentData.expires_at && (
                   <p className="text-xs text-red-600 text-center mt-1">
@@ -760,7 +760,7 @@ export default function SignPageComponent({
       </div>
       <div className="max-w-5xl mx-auto">
         <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-2">{documentData.filename}</h1>
+          <h1 className="text-3xl font-bold mb-2">{documentData.alias || documentData.filename}</h1>
           <p className="text-muted-foreground">{t("sign.clickAreas")}</p>
         </div>
 

--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -349,7 +349,7 @@ export default function SignSingleDocument({
       // Success - call onComplete callback to show completion view
       setIsGenerating(false);
       setGeneratingProgress("");
-      onComplete(documentData.filename);
+      onComplete(documentData.alias || documentData.filename);
     } catch (err) {
       console.error("Error generating signed document:", err);
       setError(
@@ -579,7 +579,7 @@ export default function SignSingleDocument({
                 </div>
                 <div className="bg-green-50 border border-green-200 rounded-md p-3">
                   <p className="text-sm text-green-700 text-center font-medium">
-                    {documentData.filename}
+                    {documentData.alias || documentData.filename}
                   </p>
                   <p className="text-xs text-green-600 text-center mt-1">
                     {t("sign.completed.status")}
@@ -621,7 +621,7 @@ export default function SignSingleDocument({
               </div>
               <div className="bg-red-50 border border-red-200 rounded-md p-3">
                 <p className="text-sm text-red-700 text-center font-medium">
-                  {documentData.filename}
+                  {documentData.alias || documentData.filename}
                 </p>
                 {documentData.expires_at && (
                   <p className="text-xs text-red-600 text-center mt-1">
@@ -662,7 +662,7 @@ export default function SignSingleDocument({
           </Button>
         )}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold mb-2">{documentData.filename}</h1>
+          <h1 className="text-3xl font-bold mb-2">{documentData.alias || documentData.filename}</h1>
           <p className="text-muted-foreground">{t("sign.clickAreas")}</p>
         </div>
 

--- a/components/dashboard/document-card.tsx
+++ b/components/dashboard/document-card.tsx
@@ -47,6 +47,9 @@ export function DocumentCard({ document }: DocumentCardProps) {
     return filename.slice(0, maxLength) + "...";
   };
 
+  // Display alias if exists, otherwise show filename
+  const displayName = document.alias || document.filename;
+
   return (
     <Link href={`/document/${document.id}`} className="block group">
       <Card className="transition-all duration-200 hover:shadow-md hover:border-primary/20 group-hover:scale-[1.02] h-48 flex flex-col">
@@ -60,9 +63,9 @@ export function DocumentCard({ document }: DocumentCardProps) {
             <FileText className="h-8 w-8 text-primary flex-shrink-0" />
             <h3
               className="font-medium text-sm leading-relaxed text-center px-2 break-words"
-              title={document.filename}
+              title={displayName}
             >
-              {truncateFilename(document.filename)}
+              {truncateFilename(displayName)}
             </h3>
           </div>
         </CardHeader>

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -7,6 +7,8 @@ import { useRouter } from "next/navigation";
 import { Upload, FileImage, Trash2, ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import AreaSelector from "@/components/area-selector";
 import {
   uploadDocument,
@@ -26,6 +28,7 @@ export default function DocumentUpload() {
   const router = useRouter();
   const [document, setDocument] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string>("");
+  const [alias, setAlias] = useState<string>("");
   const [originalFile, setOriginalFile] = useState<File | null>(null);
   const [signatureAreas, setSignatureAreas] = useState<RelativeSignatureArea[]>([]);
   const [isSelecting, setIsSelecting] = useState<boolean>(false);
@@ -87,6 +90,7 @@ export default function DocumentUpload() {
   const handleClearDocument = () => {
     setDocument(null);
     setFileName("");
+    setAlias("");
     setOriginalFile(null);
     setSignatureAreas([]);
     setError(null);
@@ -197,6 +201,9 @@ export default function DocumentUpload() {
       const formData = new FormData();
       formData.append("file", originalFile);
       formData.append("filename", fileName);
+      if (alias.trim()) {
+        formData.append("alias", alias.trim());
+      }
 
       const uploadResult = await uploadDocument(formData);
 
@@ -306,7 +313,34 @@ export default function DocumentUpload() {
             </Button>
           </div>
 
-          <h2 className="text-2xl font-semibold">{fileName}</h2>
+          {/* File Information Section */}
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="document-filename" className="text-sm font-medium">
+                {t("upload.filename")}
+              </Label>
+              <p className="text-sm text-muted-foreground mt-1">{fileName}</p>
+            </div>
+
+            <div>
+              <Label htmlFor="document-alias" className="text-sm font-medium">
+                {t("upload.alias")}
+                <span className="text-muted-foreground ml-1">({t("upload.aliasOptional")})</span>
+              </Label>
+              <Input
+                id="document-alias"
+                type="text"
+                placeholder={t("upload.aliasPlaceholder")}
+                value={alias}
+                onChange={(e) => setAlias(e.target.value)}
+                className="mt-2"
+                maxLength={100}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                {t("upload.aliasDescription")}
+              </p>
+            </div>
+          </div>
 
           <div className="relative border rounded-lg overflow-hidden">
             {/* Zoom Controls */}

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -40,6 +40,7 @@ export type Database = {
       }
       documents: {
         Row: {
+          alias: string | null
           created_at: string
           created_month: string
           deleted_at: string | null
@@ -53,6 +54,7 @@ export type Database = {
           user_id: string | null
         }
         Insert: {
+          alias?: string | null
           created_at?: string
           created_month: string
           deleted_at?: string | null
@@ -66,6 +68,7 @@ export type Database = {
           user_id?: string | null
         }
         Update: {
+          alias?: string | null
           created_at?: string
           created_month?: string
           deleted_at?: string | null


### PR DESCRIPTION
- Add optional alias field to document upload form so users can
  provide a friendly name without changing the original filename.
  - Add Input and Label components and state (alias) to the upload
    component UI.
  - Show alias field with helper text, placeholder and maxlength.
  - Include alias in FormData when uploading if provided.
  - Clear alias when resetting the upload form.

- Display alias throughout sign/publication pages when available,
  falling back to the original filename. This ensures the UI shows
  user-friendly names in headings and status cards.

- Ensure publication page always shows fresh data by disabling cache
  (dynamic = 'force-dynamic', revalidate = 0) so newly uploaded
  aliases and document changes appear immediately.

- Add alias handling placeholder in document-actions to accept the
  alias server-side (preparing for persistence).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 문서 별칭 기능 추가: 문서 업로드 시 맞춤 이름(별칭)을 설정하고 편집 가능하며, 대시보드·상세 페이지·서명 화면 등 앱 전체에서 파일명 대신 별칭으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->