### PR TITLE
✨ feat(consent): add consent pages and handlers

### DIFF
--- a/app/(auth)/auth/callback/route.ts
+++ b/app/(auth)/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 // The client you created from the Server-Side Auth instructions
+import { CURRENT_LEGAL_VERSION } from "@/lib/constants/legal";
 import { createServerSupabase } from "@/lib/supabase/server";
 
 export async function GET(request: Request) {
@@ -16,16 +17,49 @@ export async function GET(request: Request) {
     const supabase = await createServerSupabase();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      let needsConsent = false;
+
+      if (user) {
+        const provider = user.app_metadata?.provider;
+        if (provider === "kakao") {
+          const { data: profile } = await supabase
+            .from("users")
+            .select(
+              "terms_accepted_at, privacy_accepted_at, terms_accepted_version, privacy_accepted_version"
+            )
+            .eq("id", user.id)
+            .maybeSingle();
+
+          const hasConsent =
+            Boolean(profile?.terms_accepted_at) &&
+            Boolean(profile?.privacy_accepted_at) &&
+            profile?.terms_accepted_version === CURRENT_LEGAL_VERSION &&
+            profile?.privacy_accepted_version === CURRENT_LEGAL_VERSION;
+
+          needsConsent = !hasConsent;
+        }
+      }
+
       const forwardedHost = request.headers.get("x-forwarded-host"); // original origin before load balancer
       const isLocalEnv = process.env.NODE_ENV === "development";
-      if (isLocalEnv) {
-        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-        return NextResponse.redirect(`${origin}${next}`);
-      } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`);
-      } else {
-        return NextResponse.redirect(`${origin}${next}`);
+      const baseUrl = isLocalEnv
+        ? origin
+        : forwardedHost
+        ? `https://${forwardedHost}`
+        : origin;
+
+      if (needsConsent) {
+        const consentUrl = new URL("/auth/consent", baseUrl);
+        if (next && next !== "/") {
+          consentUrl.searchParams.set("next", next);
+        }
+        return NextResponse.redirect(consentUrl.toString());
       }
+
+      return NextResponse.redirect(`${baseUrl}${next}`);
     }
   }
 

--- a/app/(auth)/consent/ConsentForm.tsx
+++ b/app/(auth)/consent/ConsentForm.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { useFormState } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { useLanguage } from "@/contexts/language-context";
+
+import {
+  acceptLegalConsent,
+  declineLegalConsent,
+} from "./actions";
+
+const initialState: { error: string | null } = { error: null };
+
+export function ConsentForm({ nextPath }: { nextPath: string }) {
+  const { t } = useLanguage();
+  const [accepted, setAccepted] = useState(false);
+  const [{ error }, formAction] = useFormState(acceptLegalConsent, initialState);
+
+  return (
+    <div className="space-y-6">
+      <form action={formAction} className="space-y-4">
+        <input type="hidden" name="next" value={nextPath} />
+
+        <div className="flex items-start space-x-3 rounded-md border border-border bg-muted/30 p-4">
+          <Checkbox
+            id="consent"
+            checked={accepted}
+            onCheckedChange={(value) => setAccepted(Boolean(value))}
+          />
+          <label
+            htmlFor="consent"
+            className="text-sm leading-relaxed text-muted-foreground"
+          >
+            {t("consent.checkbox")}
+          </label>
+        </div>
+
+        {error && (
+          <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {t(error)}
+          </p>
+        )}
+
+        <Button
+          type="submit"
+          className="w-full"
+          disabled={!accepted}
+        >
+          {t("consent.agreeButton")}
+        </Button>
+      </form>
+
+      <div className="rounded-md border border-border px-4 py-3 text-sm text-muted-foreground">
+        <p>{t("consent.declineNotice")}</p>
+      </div>
+
+      <form action={declineLegalConsent}>
+        <Button type="submit" variant="outline" className="w-full">
+          {t("consent.declineButton")}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/app/(auth)/consent/ConsentPageContent.tsx
+++ b/app/(auth)/consent/ConsentPageContent.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import Link from "next/link";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useLanguage } from "@/contexts/language-context";
+
+import { ConsentForm } from "./ConsentForm";
+
+export function ConsentPageContent({ nextPath }: { nextPath: string }) {
+  const { t } = useLanguage();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 px-4 py-10">
+      <Card className="w-full max-w-xl">
+        <CardHeader className="space-y-3">
+          <CardTitle>{t("consent.title")}</CardTitle>
+          <CardDescription className="text-base leading-relaxed">
+            {t("consent.subtitle")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="rounded-md border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+            <p>{t("consent.linksDescription")}</p>
+            <ul className="mt-3 list-disc space-y-1 pl-6">
+              <li>
+                <Link
+                  href="/term"
+                  target="_blank"
+                  className="font-medium text-primary hover:underline"
+                >
+                  {t("consent.viewTerms")}
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/privacy"
+                  target="_blank"
+                  className="font-medium text-primary hover:underline"
+                >
+                  {t("consent.viewPrivacy")}
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <ConsentForm nextPath={nextPath} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default ConsentPageContent;

--- a/app/(auth)/consent/actions.ts
+++ b/app/(auth)/consent/actions.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { CURRENT_LEGAL_VERSION } from "@/lib/constants/legal";
+import { createServerSupabase } from "@/lib/supabase/server";
+
+export async function acceptLegalConsent(_: any, formData: FormData) {
+  const supabase = await createServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const nextParam = formData.get("next");
+  const nextPath =
+    typeof nextParam === "string" && nextParam.startsWith("/")
+      ? nextParam
+      : "/";
+
+  const timestamp = new Date().toISOString();
+
+  const { error } = await supabase
+    .from("users")
+    .update({
+      terms_accepted_at: timestamp,
+      terms_accepted_version: CURRENT_LEGAL_VERSION,
+      privacy_accepted_at: timestamp,
+      privacy_accepted_version: CURRENT_LEGAL_VERSION,
+    })
+    .eq("id", user.id);
+
+  if (error) {
+    console.error("Failed to update legal consent:", error);
+    return {
+      error: "consent.error",
+    };
+  }
+
+  revalidatePath("/", "layout");
+  redirect(nextPath);
+}
+
+export async function declineLegalConsent() {
+  const supabase = await createServerSupabase();
+  await supabase.auth.signOut();
+  redirect("/login?error=consent_required");
+}

--- a/app/(auth)/consent/page.tsx
+++ b/app/(auth)/consent/page.tsx
@@ -1,0 +1,63 @@
+import { redirect } from "next/navigation";
+
+import { CURRENT_LEGAL_VERSION } from "@/lib/constants/legal";
+import { createServerSupabase } from "@/lib/supabase/server";
+
+import { ConsentPageContent } from "./ConsentPageContent";
+
+function parseNextParam(rawNext: string | null): string {
+  if (!rawNext) return "/";
+  try {
+    const decoded = decodeURIComponent(rawNext);
+    if (decoded.startsWith("/")) {
+      return decoded;
+    }
+  } catch {
+    // ignore decode errors
+  }
+  return "/";
+}
+
+interface ConsentPageProps {
+  searchParams: Record<string, string | string[] | undefined>;
+}
+
+export default async function ConsentPage({ searchParams }: ConsentPageProps) {
+  const supabase = await createServerSupabase();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login");
+  }
+
+  const { data: profile } = await supabase
+    .from("users")
+    .select(
+      "terms_accepted_at, privacy_accepted_at, terms_accepted_version, privacy_accepted_version"
+    )
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const hasConsent =
+    Boolean(profile?.terms_accepted_at) &&
+    Boolean(profile?.privacy_accepted_at) &&
+    profile?.terms_accepted_version === CURRENT_LEGAL_VERSION &&
+    profile?.privacy_accepted_version === CURRENT_LEGAL_VERSION;
+
+  const requestedNext =
+    typeof searchParams?.next === "string"
+      ? searchParams.next
+      : Array.isArray(searchParams?.next)
+      ? searchParams.next[0]
+      : null;
+
+  const nextPath = parseNextParam(requestedNext);
+
+  if (hasConsent) {
+    redirect(nextPath);
+  }
+
+  return <ConsentPageContent nextPath={nextPath} />;
+}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -248,6 +248,20 @@ const translations: Record<Language, Record<string, string>> = {
       "메일이 보이지 않으면 스팸 폴더를 확인해주세요.",
     "register.success.goToLogin": "로그인 화면으로",
 
+    // Consent Page
+    "consent.title": "서비스 이용을 위해 약관에 동의해주세요",
+    "consent.subtitle":
+      "카카오 계정으로 로그인하셨다면 슥슥 이용약관과 개인정보 처리방침에 대한 동의가 추가로 필요합니다.",
+    "consent.linksDescription": "아래 문서를 확인한 뒤 동의 여부를 선택해주세요.",
+    "consent.viewTerms": "슥슥 이용약관 보기",
+    "consent.viewPrivacy": "개인정보 처리방침 보기",
+    "consent.checkbox": "슥슥 이용약관과 개인정보 처리방침을 모두 읽었으며 이에 동의합니다.",
+    "consent.agreeButton": "동의하고 계속하기",
+    "consent.declineNotice":
+      "동의하지 않을 경우 서비스를 이용할 수 없습니다. 동의하지 않는다면 로그아웃 후 이용을 중단해주세요.",
+    "consent.declineButton": "동의하지 않고 로그아웃",
+    "consent.error": "약관 동의 처리 중 문제가 발생했습니다. 다시 시도해주세요.",
+
     // Sign Page - Password Protection & Status
     "sign.password.title": "보안 문서",
     "sign.password.description": "이 문서는 비밀번호로 보호되어 있습니다.",
@@ -1246,6 +1260,20 @@ const translations: Record<Language, Record<string, string>> = {
     "register.success.checkSpam":
       "If you don't see the email, please check your spam folder.",
     "register.success.goToLogin": "Go to Login",
+
+    // Consent Page
+    "consent.title": "Please accept our terms to continue",
+    "consent.subtitle":
+      "Even after signing in with Kakao, you need to agree to the SeukSeuk Terms of Service and Privacy Policy before using the service.",
+    "consent.linksDescription": "Review the documents below and choose how you’d like to proceed.",
+    "consent.viewTerms": "View Terms of Service",
+    "consent.viewPrivacy": "View Privacy Policy",
+    "consent.checkbox": "I have read and agree to the SeukSeuk Terms of Service and Privacy Policy.",
+    "consent.agreeButton": "Agree and continue",
+    "consent.declineNotice":
+      "You won’t be able to use the service unless you agree. If you choose not to agree, you’ll be signed out.",
+    "consent.declineButton": "Sign out without agreeing",
+    "consent.error": "We couldn’t record your consent. Please try again.",
 
     // Sign Page - Password Protection & Status
     "sign.password.title": "Protected Document",

--- a/lib/constants/legal.ts
+++ b/lib/constants/legal.ts
@@ -1,0 +1,1 @@
+export const CURRENT_LEGAL_VERSION = "2025-10-01";

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -327,6 +327,10 @@ export type Database = {
           current_subscription_id: string | null
           id: string
           name: string
+          privacy_accepted_at: string | null
+          privacy_accepted_version: string | null
+          terms_accepted_at: string | null
+          terms_accepted_version: string | null
           updated_at: string
         }
         Insert: {
@@ -335,6 +339,10 @@ export type Database = {
           current_subscription_id?: string | null
           id: string
           name: string
+          privacy_accepted_at?: string | null
+          privacy_accepted_version?: string | null
+          terms_accepted_at?: string | null
+          terms_accepted_version?: string | null
           updated_at?: string
         }
         Update: {
@@ -343,6 +351,10 @@ export type Database = {
           current_subscription_id?: string | null
           id?: string
           name?: string
+          privacy_accepted_at?: string | null
+          privacy_accepted_version?: string | null
+          terms_accepted_at?: string | null
+          terms_accepted_version?: string | null
           updated_at?: string
         }
         Relationships: [


### PR DESCRIPTION
Add a full consent flow to the auth area, including a client-side
ConsentForm and ConsentPageContent, a server-side ConsentPage that
checks current user consent, and a legal constants file.

- Add ConsentForm component with checkbox agree/decline actions and
  client-side form state. Disable submit until the user accepts and
  surface server error messages.
- Add ConsentPageContent to present the consent card, localized text,
  and links to legal documents.
- Add ConsentPage (server) to verify authenticated user, load the user
  profile from Supabase, compare accepted versions against
  CURRENT_LEGAL_VERSION, parse a safe "next" redirect parameter, and
  redirect away when consent is already satisfied.
- Introduce lib/constants/legal.ts with CURRENT_LEGAL_VERSION to
  centralize legal versioning.
- Wire declineLegalConsent and acceptLegalConsent actions into forms
  (actions implemented elsewhere) and ensure proper navigation flow.

These changes enforce up-to-date legal consent checks and provide a
user-friendly consent UI to collect or decline legal agreements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이용약관 및 개인정보 보호정책 동의 플로우 추가
  * 로그인 후 동의 페이지 표시 (필수)
  * 동의 관리 기능: 약관 수락 또는 거부 선택 가능
  * 로컬라이제이션 지원 (한국어, 영어)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->