### PR TITLE
✨ feat: revamp dashboard header and add publish UI strings

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -26,7 +26,7 @@ import {
   convertSignatureAreaToPixels,
   type RelativeSignatureArea,
 } from "@/lib/utils";
-import { Edit, Download, Trash2, ZoomIn, ZoomOut, RotateCcw } from "lucide-react";
+import { Edit, Download, Trash2, ZoomIn, ZoomOut, RotateCcw, Share2 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useRef, useState, useEffect } from "react";
@@ -438,7 +438,7 @@ export default function DocumentDetailComponent({
             <div className="sm:hidden">
               {!isEditMode ? (
                 <>
-                  {/* Draft State - Edit and Delete Actions */}
+                  {/* Draft State - Edit, Publish and Delete Actions */}
                   {canEdit && (
                     <div className="flex justify-between items-center mb-8">
                       {/* Left Group - Edit & Delete */}
@@ -462,6 +462,17 @@ export default function DocumentDetailComponent({
                           {t("documentDetail.delete")}
                         </Button>
                       </div>
+                      {/* Right Group - Publish */}
+                      <Link href="/publish">
+                        <Button
+                          variant="outline"
+                          disabled={isLoading}
+                          className="h-9 px-3 text-sm font-medium border-2 hover:bg-gray-50"
+                        >
+                          <Share2 className="mr-1 h-3 w-3" />
+                          {t("documentDetail.publish")}
+                        </Button>
+                      </Link>
                     </div>
                   )}
                   {/* Completed State - Download and Delete */}
@@ -552,7 +563,7 @@ export default function DocumentDetailComponent({
             <div className="hidden sm:block">
               {!isEditMode ? (
                 <>
-                  {/* Draft State - Edit and Delete Actions */}
+                  {/* Draft State - Edit, Publish and Delete Actions */}
                   {canEdit && (
                     <div className="flex justify-between items-center mb-8">
                       {/* Left Group - Edit & Delete */}
@@ -576,6 +587,17 @@ export default function DocumentDetailComponent({
                           {t("documentDetail.delete")}
                         </Button>
                       </div>
+                      {/* Right Group - Publish */}
+                      <Link href="/publish">
+                        <Button
+                          variant="outline"
+                          disabled={isLoading}
+                          className="h-10 px-4 text-sm font-medium border-2 hover:bg-gray-50"
+                        >
+                          <Share2 className="mr-2 h-4 w-4" />
+                          {t("documentDetail.publish")}
+                        </Button>
+                      </Link>
                     </div>
                   )}
                   {/* Completed State - Download and Delete */}

--- a/app/(document)/publish/components/PublishPageContent.tsx
+++ b/app/(document)/publish/components/PublishPageContent.tsx
@@ -4,6 +4,10 @@ import { ProjectBreadcrumb } from "@/components/breadcrumb";
 import PublishForm from "@/components/publish/publish-form";
 import type { Document } from "@/lib/supabase/database.types";
 import { useLanguage } from "@/contexts/language-context";
+import { PublicationsList } from "@/components/dashboard/publications-list";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { Upload } from "lucide-react";
 
 interface PublishPageContentProps {
   documents: Document[];
@@ -14,12 +18,38 @@ export default function PublishPageContent({ documents }: PublishPageContentProp
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="max-w-2xl mx-auto">
+      <div className="max-w-6xl mx-auto">
         {/* Breadcrumb */}
         <ProjectBreadcrumb />
 
         <h1 className="text-2xl font-bold mb-6">{t("publish.title")}</h1>
-        <PublishForm documents={documents} />
+
+        {documents.length === 0 ? (
+          <div className="space-y-8">
+            {/* No drafts message */}
+            <div className="bg-muted px-4 py-8 rounded-lg text-center max-w-2xl mx-auto">
+              <p className="text-muted-foreground mb-4">
+                {t("publish.noDrafts")}
+              </p>
+              <Link href="/upload">
+                <Button className="gap-2">
+                  <Upload className="h-4 w-4" />
+                  {t("publish.uploadDocument")}
+                </Button>
+              </Link>
+            </div>
+
+            {/* Show existing publications */}
+            <div>
+              <h2 className="text-xl font-semibold mb-4">{t("publish.existingPublications")}</h2>
+              <PublicationsList />
+            </div>
+          </div>
+        ) : (
+          <div className="max-w-2xl mx-auto">
+            <PublishForm documents={documents} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/(document)/publish/page.tsx
+++ b/app/(document)/publish/page.tsx
@@ -32,26 +32,5 @@ export default async function PublishPage() {
     );
   }
 
-  if (documents.length === 0) {
-    return (
-      <div className="container mx-auto px-4 py-8">
-        <div className="max-w-2xl mx-auto">
-          <h1 className="text-2xl font-bold mb-6">문서 발행</h1>
-          <div className="bg-muted px-4 py-8 rounded-lg text-center">
-            <p className="text-muted-foreground mb-4">
-              발행할 수 있는 문서가 없습니다.
-            </p>
-            <a
-              href="/upload"
-              className="inline-block px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
-            >
-              문서 업로드하기
-            </a>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return <PublishPageContent documents={documents} />;
 }

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -10,31 +10,31 @@ export function DashboardHeader() {
   const { t } = useLanguage();
 
   return (
-    <div className="space-y-8 mb-8">
-      {/* Header Section */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight mb-2">
-            {t("dashboard.header.title")}
-          </h1>
-          <p className="text-muted-foreground">
-            {t("dashboard.header.description")}
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Link href="/publish">
-            <Button variant="outline" className="gap-2">
-              <Share2 className="h-4 w-4" />
-              {t("dashboard.publish")}
-            </Button>
-          </Link>
-          <Link href="/upload">
-            <Button className="gap-2">
-              <Plus className="h-4 w-4" />
-              {t("dashboard.upload")}
-            </Button>
-          </Link>
-        </div>
+    <div className="space-y-6 mb-8">
+      {/* Title and Description */}
+      <div>
+        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+          {t("dashboard.header.title")}
+        </h1>
+        <p className="text-sm sm:text-base text-muted-foreground">
+          {t("dashboard.header.description")}
+        </p>
+      </div>
+
+      {/* Action Buttons - Mobile & Desktop: 2 buttons in a row */}
+      <div className="flex flex-row gap-2">
+        <Link href="/publish" className="flex-1 sm:flex-initial">
+          <Button variant="outline" className="w-full gap-2">
+            <Share2 className="h-4 w-4" />
+            {t("dashboard.publish")}
+          </Button>
+        </Link>
+        <Link href="/upload" className="flex-1 sm:flex-initial">
+          <Button className="w-full gap-2">
+            <Plus className="h-4 w-4" />
+            {t("dashboard.upload")}
+          </Button>
+        </Link>
       </div>
 
       {/* Usage Widget */}

--- a/components/dashboard/dashboard-header.tsx
+++ b/components/dashboard/dashboard-header.tsx
@@ -10,31 +10,34 @@ export function DashboardHeader() {
   const { t } = useLanguage();
 
   return (
-    <div className="space-y-6 mb-8">
-      {/* Title and Description */}
-      <div>
-        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight mb-2">
-          {t("dashboard.header.title")}
-        </h1>
-        <p className="text-sm sm:text-base text-muted-foreground">
-          {t("dashboard.header.description")}
-        </p>
-      </div>
+    <div className="space-y-8 mb-8">
+      {/* Header Section */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        {/* Title and Description */}
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+            {t("dashboard.header.title")}
+          </h1>
+          <p className="text-sm sm:text-base text-muted-foreground">
+            {t("dashboard.header.description")}
+          </p>
+        </div>
 
-      {/* Action Buttons - Mobile & Desktop: 2 buttons in a row */}
-      <div className="flex flex-row gap-2">
-        <Link href="/publish" className="flex-1 sm:flex-initial">
-          <Button variant="outline" className="w-full gap-2">
-            <Share2 className="h-4 w-4" />
-            {t("dashboard.publish")}
-          </Button>
-        </Link>
-        <Link href="/upload" className="flex-1 sm:flex-initial">
-          <Button className="w-full gap-2">
-            <Plus className="h-4 w-4" />
-            {t("dashboard.upload")}
-          </Button>
-        </Link>
+        {/* Action Buttons - Mobile: Full width row, Desktop: Right aligned */}
+        <div className="flex flex-row gap-2">
+          <Link href="/publish" className="flex-1 sm:flex-initial">
+            <Button variant="outline" className="w-full gap-2">
+              <Share2 className="h-4 w-4" />
+              {t("dashboard.publish")}
+            </Button>
+          </Link>
+          <Link href="/upload" className="flex-1 sm:flex-initial">
+            <Button className="w-full gap-2">
+              <Plus className="h-4 w-4" />
+              {t("dashboard.upload")}
+            </Button>
+          </Link>
+        </div>
       </div>
 
       {/* Usage Widget */}

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -1320,7 +1320,7 @@ const translations: Record<Language, Record<string, string>> = {
     "dashboard.header.title": "My Documents",
     "dashboard.header.description":
       "Manage your documents and collect signatures",
-    "dashboard.publish": "Publish Document",
+    "dashboard.publish": "Publish",
     "dashboard.upload": "Upload",
     "dashboard.empty.title": "No documents uploaded yet",
     "dashboard.empty.description":

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -312,8 +312,8 @@ const translations: Record<Language, Record<string, string>> = {
     "dashboard.error.loadMore": "추가 문서를 불러오는 중 오류가 발생했습니다.",
     "dashboard.filter.all": "전체",
     "dashboard.filter.draft": "초안",
-    "dashboard.filter.published": "게시됨",
-    "dashboard.filter.completed": "완료됨",
+    "dashboard.filter.published": "발행",
+    "dashboard.filter.completed": "완료",
     "dashboard.tabs.documents": "문서",
     "dashboard.tabs.publications": "발행",
     "dashboard.publications.empty.title": "발행된 문서가 없습니다",
@@ -385,8 +385,8 @@ const translations: Record<Language, Record<string, string>> = {
 
     // Document Status
     "status.draft": "초안",
-    "status.published": "게시됨",
-    "status.completed": "완료됨",
+    "status.published": "발행",
+    "status.completed": "완료",
     "status.active": "활성",
     "status.paid": "결제 완료",
     "status.trialing": "체험 중",
@@ -406,7 +406,7 @@ const translations: Record<Language, Record<string, string>> = {
     "usage.monthly.title": "이번 달 문서 생성",
     "usage.monthly.unlimited": "무제한",
     "usage.monthly.limit.reached": "월별 문서 생성 제한에 도달했습니다",
-    "usage.active.title": "활성 문서 (게시됨 + 완료됨)",
+    "usage.active.title": "활성 문서 (발행 + 완료)",
     "usage.active.limit.reached": "활성 문서 제한에 도달했습니다",
     "usage.plan.free": "베이직",
     "usage.plan.suffix": "플랜",
@@ -502,6 +502,7 @@ const translations: Record<Language, Record<string, string>> = {
 
     // Document Detail
     "documentDetail.edit": "수정",
+    "documentDetail.publish": "발행",
     "documentDetail.delete": "삭제",
     "documentDetail.download": "다운로드",
     "documentDetail.cancel": "취소",
@@ -534,6 +535,9 @@ const translations: Record<Language, Record<string, string>> = {
     "publish.cancel": "취소",
     "publish.submit": "발행하기",
     "publish.submitting": "발행 중...",
+    "publish.noDrafts": "발행할 수 있는 초안 문서가 없습니다.",
+    "publish.uploadDocument": "문서 업로드하기",
+    "publish.existingPublications": "기존 발행 목록",
 
     // Footer
     "footer.terms": "이용약관",
@@ -1519,6 +1523,7 @@ const translations: Record<Language, Record<string, string>> = {
 
     // Document Detail
     "documentDetail.edit": "Edit",
+    "documentDetail.publish": "Publish",
     "documentDetail.delete": "Delete",
     "documentDetail.download": "Download",
     "documentDetail.cancel": "Cancel",
@@ -1551,6 +1556,9 @@ const translations: Record<Language, Record<string, string>> = {
     "publish.cancel": "Cancel",
     "publish.submit": "Publish",
     "publish.submitting": "Publishing...",
+    "publish.noDrafts": "No draft documents available to publish.",
+    "publish.uploadDocument": "Upload Document",
+    "publish.existingPublications": "Existing Publications",
 
     // Footer
     "footer.terms": "Terms of Service",


### PR DESCRIPTION
Update dashboard header layout for responsive presentation and
improve mobile/desktop action button behavior. Reduce vertical
spacing, adjust title and description typography, and move action
buttons below the title so they render as a responsive two-button
row. Make buttons full-width on small screens and revert to
intrinsic size on larger viewports by using flex-1 and sm:flex-initial
and adding w-full to Button wrappers.

Add new localization keys and adjust copy in Korean and English to
standardize terminology from "게시됨/완료됨" to "발행/완료" (published
→ publish term), and add missing strings related to publishing:
documentDetail.publish, publish.noDrafts, publish.uploadDocument,
publish.existingPublications. These changes support the updated UI
and provide clearer user-facing text for the publish workflow.

Also import PublicationsList, Button, Link, and Upload into the
publish page content and expand the container width to max-w-6xl to
accommodate the new layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 문서 상세 페이지에 발행 버튼 추가
  * 발행 페이지에 미발행 문서 없을 때 메시지 및 업로드 버튼 표시
  * 발행된 문서 목록 표시 기능 추가

* **Style**
  * 대시보드 헤더 레이아웃 최적화 및 반응형 디자인 개선

* **Chores**
  * 발행 관련 다국어 번역 문자열 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->