### PR TITLE
✨ feat(contact,payments): save submissions and send notifications

### DIFF
--- a/app/(home)/components/HomePage.tsx
+++ b/app/(home)/components/HomePage.tsx
@@ -442,7 +442,7 @@ export default function HomePageComponent() {
             <p className="text-muted-foreground mb-8 max-w-2xl mx-auto">
               {t("home.cta.description")}
             </p>
-            <Link href="/upload">
+            <Link href="/contact">
               <Button
                 size="lg"
                 className="bg-primary hover:bg-primary/90 gap-2 text-white"

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -188,10 +188,10 @@ const translations: Record<Language, Record<string, string>> = {
       "구독 세부 정보가 포함된 확인 이메일이 곧 발송됩니다.",
     "checkout.success.dashboard": "대시보드로 이동",
 
-    "home.cta.title": "지금 바로 시작하세요",
+    "home.cta.title": "궁금한 점이 있으신가요?",
     "home.cta.description":
-      "슥슥으로 문서 서명 프로세스를 간소화하고 시간과 비용을 절약하세요.",
-    "home.cta.button": "지금 시작하기",
+      "슥슥 팀이 도와드리겠습니다. 언제든지 문의해 주세요.",
+    "home.cta.button": "문의하기",
     "home.footer.rights": "모든 권리 보유.",
 
     // 테마 전환 버튼
@@ -1205,10 +1205,10 @@ const translations: Record<Language, Record<string, string>> = {
       "You will receive a confirmation email shortly with your subscription details.",
     "checkout.success.dashboard": "Go to Dashboard",
 
-    "home.cta.title": "Get Started Today",
+    "home.cta.title": "Have Questions?",
     "home.cta.description":
-      "Streamline your document signing process and save time and money with SeukSeuk.",
-    "home.cta.button": "Get Started",
+      "Our team is here to help. Feel free to reach out anytime.",
+    "home.cta.button": "Contact Us",
     "home.footer.rights": "All rights reserved.",
 
     // 테마 전환 버튼


### PR DESCRIPTION
Save contact form submissions to Supabase and replace Resend email
logic with a POST notification flow. Persist name/email/subject/message
to the contact_submissions table and POST a localized payload to the
 NOTIFICATION_ENDPOINT. Failures to persist return a user-
facing error; notification failures are logged but non-fatal.

Also add payment notification wiring in Paddle webhook processing:
- call sendPaymentNotification after linking subscriptions or when
  linking an existing subscription
- implement sendPaymentNotification to fetch subscription + plan info,
  log outcomes, and POST a localized payment notification to the
  NOTIFICATION_ENDPOINT (safe-noop if endpoint is not configured)

These changes centralize notifications, persist contact data for audit/
follow-up, and decouple notifications from a third-party email provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 연락처 양식 제출 기능 추가

* **개선 사항**
  * 홈페이지 CTA 섹션 메시지를 "궁금한 점이 있으신가요?"로 개편
  * CTA 버튼 텍스트를 "문의하기"로 업데이트
  * CTA 버튼 이동 경로를 연락처 페이지로 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->