### PR TITLE
✨ feat(signature): increase pen width to improve visibility

### DIFF
--- a/components/signature-modal.tsx
+++ b/components/signature-modal.tsx
@@ -34,7 +34,7 @@ export default function SignatureModal({
   const [lastX, setLastX] = useState(0);
   const [lastY, setLastY] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const PEN_WIDTH = 5; // Increased from default
+  const PEN_WIDTH = 8; // Increased from default
 
   // Initialize canvas when component mounts or when isOpen changes
   useEffect(() => {


### PR DESCRIPTION
Increase default pen width from 5 to 8 in the signature modal to
make strokes more visible and readable on different screen densities.
This change improves usability for users with touch devices and
ensures signatures remain clear when submitted.

Why:
- 5px produced thin strokes on high-DPI displays and small touchpads.
- 8px provides better visual feedback and more consistent results
  across devices without changing other drawing behavior.