### PR TITLE
발행 상세에서 문서 alias 노출되도록 수정

### DIFF
--- a/components/publication/publication-detail-content.tsx
+++ b/components/publication/publication-detail-content.tsx
@@ -386,7 +386,7 @@ export function PublicationDetailContent({
                     <CardContent className="p-4">
                       <div className="flex items-center justify-between">
                         <div className="flex-1">
-                          <p className="font-medium">{document.filename}</p>
+                          <p className="font-medium">{document.alias || document.filename}</p>
                           <div className="flex items-center gap-4 mt-1 text-sm text-muted-foreground">
                             <span>
                               {t("publicationDetail.createdAt")}:{" "}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 문서 목록에서 문서 이름 표시 방식을 개선했습니다. 이제 별칭이 있을 경우 별칭을 우선 표시하며, 별칭이 없을 경우에만 파일명을 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->