### PR TITLE
fix: 발행 데이터 생성 시 문서목록에 alias 노출되도록 수정

### DIFF
--- a/components/publish/publish-form.tsx
+++ b/components/publish/publish-form.tsx
@@ -220,7 +220,7 @@ export default function PublishForm({ documents }: PublishFormProps) {
                     onCheckedChange={() => handleDocumentToggle(document.id)}
                   />
                   <div className="flex-1">
-                    <p className="font-medium">{document.filename}</p>
+                    <p className="font-medium">{document.alias || document.filename}</p>
                     <p className="text-sm text-muted-foreground">
                       {new Date(document.created_at).toLocaleDateString(
                         language === "ko" ? "ko-KR" : "en-US"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 게시 양식에서 문서 이름 표시 시 별칭이 있으면 별칭을 우선적으로 표시하고, 별칭이 없으면 파일명을 표시하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->