### PR TITLE
fix: ToastViewport가 헤더 버튼 클릭을 가로채는 문제 수정

### DIFF
--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 pointer-events-none sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- `ToastViewport`가 `fixed top-0 z-[100] w-full`로 렌더링되어 헤더(`z-50`) 위에 보이지 않는 레이어를 형성, 언어 선택 버튼과 아바타 드롭다운 클릭이 불가능했던 문제 수정
- `pointer-events-none`을 ToastViewport에 추가하여 해결 (개별 Toast에는 이미 `pointer-events-auto`가 적용되어 있어 토스트 알림 클릭은 정상 동작)

## Test plan
- [x] 언어 선택 드롭다운 클릭 동작 확인
- [x] 아바타 드롭다운 메뉴 클릭 동작 확인
- [x] 토스트 알림 표시 및 클릭(닫기) 정상 동작 확인
- [x] 모바일/데스크탑 양쪽에서 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)