### PR TITLE
fix: PDF 버튼 PRO 뱃지 정렬 및 네이버 서치어드바이저 meta 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -55,7 +55,9 @@ export default async function RootLayout({
 
   return (
     <html lang={language === "ko" ? "ko" : "en"} suppressHydrationWarning>
-      <head />
+      <head>
+        <meta name="naver-site-verification" content="24ae5cf6d9a265c90d7a677e7b820b8fbb00472b" />
+      </head>
       <body className={inter.className}>
         <ThemeProvider
           attribute="class"

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -534,12 +534,12 @@ export default function DocumentUpload() {
                   {t("pdf_document")}
                 </span>
                 {!canUsePdf ? (
-                  <span className="absolute left-[calc(50%+1.5em)] ml-1 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground whitespace-nowrap">
+                  <span className="absolute left-[calc(50%+1.5em)] ml-2 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground whitespace-nowrap">
                     <Lock className="h-3 w-3" />
                     {t("pdf_pro_badge")}
                   </span>
                 ) : (
-                  <span className="absolute left-[calc(50%+1.5em)] ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary whitespace-nowrap">
+                  <span className="absolute left-[calc(50%+1.5em)] ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary whitespace-nowrap">
                     {t("pdf_pro_badge")}
                   </span>
                 )}

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -529,17 +529,17 @@ export default function DocumentUpload() {
               }`}
             >
               <FileText className={`h-6 w-6 ${uploadMode === 'pdf' ? 'text-primary' : 'text-muted-foreground'}`} />
-              <div className="flex items-center justify-center">
+              <div className="relative flex items-center justify-center w-full">
                 <span className={`text-sm font-medium ${uploadMode === 'pdf' ? 'text-primary' : 'text-muted-foreground'}`}>
                   {t("pdf_document")}
                 </span>
                 {!canUsePdf ? (
-                  <span className="ml-1.5 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground">
+                  <span className="absolute left-[calc(50%+1.5em)] ml-1 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground whitespace-nowrap">
                     <Lock className="h-3 w-3" />
                     {t("pdf_pro_badge")}
                   </span>
                 ) : (
-                  <span className="ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary">
+                  <span className="absolute left-[calc(50%+1.5em)] ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary whitespace-nowrap">
                     {t("pdf_pro_badge")}
                   </span>
                 )}

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -529,20 +529,20 @@ export default function DocumentUpload() {
               }`}
             >
               <FileText className={`h-6 w-6 ${uploadMode === 'pdf' ? 'text-primary' : 'text-muted-foreground'}`} />
-              <div className="relative flex items-center justify-center w-full">
-                <span className={`text-sm font-medium ${uploadMode === 'pdf' ? 'text-primary' : 'text-muted-foreground'}`}>
+              <div className="flex items-center justify-center w-full">
+                <span className={`relative text-sm font-medium ${uploadMode === 'pdf' ? 'text-primary' : 'text-muted-foreground'}`}>
                   {t("pdf_document")}
+                  {!canUsePdf ? (
+                    <span className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground whitespace-nowrap">
+                      <Lock className="h-3 w-3" />
+                      {t("pdf_pro_badge")}
+                    </span>
+                  ) : (
+                    <span className="absolute left-full top-1/2 -translate-y-1/2 ml-1.5 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary whitespace-nowrap">
+                      {t("pdf_pro_badge")}
+                    </span>
+                  )}
                 </span>
-                {!canUsePdf ? (
-                  <span className="absolute left-[calc(50%+1.5em)] ml-2 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full text-xs font-medium bg-muted text-muted-foreground whitespace-nowrap">
-                    <Lock className="h-3 w-3" />
-                    {t("pdf_pro_badge")}
-                  </span>
-                ) : (
-                  <span className="absolute left-[calc(50%+1.5em)] ml-2 inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary whitespace-nowrap">
-                    {t("pdf_pro_badge")}
-                  </span>
-                )}
               </div>
             </button>
           </div>


### PR DESCRIPTION
## Summary
- PDF 문서 버튼의 PRO 뱃지를 absolute 포지셔닝으로 분리하여 'PDF 문서' 텍스트 기준 가운데 정렬 유지
- 네이버 서치어드바이저 사이트 인증 meta 태그 추가

## Test plan
- [ ] PDF 문서 버튼에서 'PDF 문서' 텍스트가 버튼 중앙에 정렬되는지 확인
- [ ] PRO 뱃지가 텍스트 오른쪽에 올바르게 붙어있는지 확인
- [ ] 네이버 서치어드바이저에서 사이트 인증이 정상 처리되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * PDF 업로드 옵션의 배지 위치가 개선되었습니다. 배지가 옵션 컨테이너 내에서 일관되게 정렬되어 더 나은 시각적 레이아웃을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->