### PR TITLE
fix: 서명 펜 굵기 조정 및 텍스트 입력 폰트 크기 개선

### DIFF
--- a/components/signature-modal.tsx
+++ b/components/signature-modal.tsx
@@ -34,7 +34,7 @@ export default function SignatureModal({
   const [lastX, setLastX] = useState(0);
   const [lastY, setLastY] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const PEN_WIDTH = 8; // Increased from default
+  const PEN_WIDTH = 5;
 
   // Initialize canvas when component mounts or when isOpen changes
   useEffect(() => {

--- a/components/text-input-modal.tsx
+++ b/components/text-input-modal.tsx
@@ -81,43 +81,24 @@ export default function TextInputModal({
     const maxHeight = logicalHeight - padding * 2;
     const fontFamily = '-apple-system, "Noto Sans KR", sans-serif';
 
-    // Dynamic font sizing: find the largest font that fits the canvas
-    let fontSize = 200; // start large
-    let lines: string[] = [];
-    while (fontSize > 20) {
-      ctx.font = `bold ${fontSize}px ${fontFamily}`;
-      lines = wrapText(ctx, inputText, maxWidth);
-      const totalHeight = lines.length * fontSize * 1.3;
-      if (totalHeight <= maxHeight) break;
+    // Dynamic font sizing: single line, fit to fill the width
+    let fontSize = maxHeight; // start with max height as upper bound
+    ctx.font = `bold ${fontSize}px ${fontFamily}`;
+    while (fontSize > 20 && ctx.measureText(inputText).width > maxWidth) {
       fontSize -= 4;
+      ctx.font = `bold ${fontSize}px ${fontFamily}`;
     }
-
-    // If single line, also check width and shrink if needed
-    if (lines.length === 1) {
-      while (fontSize > 20 && ctx.measureText(lines[0]).width > maxWidth) {
-        fontSize -= 4;
-        ctx.font = `bold ${fontSize}px ${fontFamily}`;
-      }
-    }
-
-    const lineHeight = fontSize * 1.3;
-    const totalTextHeight = lines.length * lineHeight;
 
     ctx.clearRect(0, 0, logicalWidth, logicalHeight);
     ctx.font = `bold ${fontSize}px ${fontFamily}`;
     ctx.fillStyle = "#000000";
-    ctx.textBaseline = "top";
+    ctx.textBaseline = "middle";
 
-    // Center text vertically
-    let y = Math.max(padding, (logicalHeight - totalTextHeight) / 2);
-    for (const line of lines) {
-      // Center text horizontally
-      const lineWidth = ctx.measureText(line).width;
-      const x = (logicalWidth - lineWidth) / 2;
-      ctx.fillText(line, x, y);
-      y += lineHeight;
-      if (y + lineHeight > logicalHeight) break;
-    }
+    // Center text
+    const textWidth = ctx.measureText(inputText).width;
+    const x = (logicalWidth - textWidth) / 2;
+    const y = logicalHeight / 2;
+    ctx.fillText(inputText, x, y);
 
     return canvas.toDataURL("image/png");
   };

--- a/components/text-input-modal.tsx
+++ b/components/text-input-modal.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import { Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
 import {
   Dialog,
   DialogContent,
@@ -122,12 +122,10 @@ export default function TextInputModal({
         </DialogHeader>
 
         <div className="my-4">
-          <Textarea
+          <Input
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder={t("textModal.placeholder")}
-            rows={5}
-            className="resize-none"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- 서명 모달의 캔버스 펜 굵기를 8에서 5로 줄여 더 섬세한 서명이 가능하도록 변경
- 텍스트 입력 모달의 폰트를 줄바꿈 없이 한 줄로 유지하면서 영역 가로폭에 꽉 차는 크기로 자동 조정

## Test plan
- [ ] 서명 페이지에서 서명 캔버스 펜 굵기가 가늘어졌는지 확인
- [ ] 텍스트 입력 시 한 줄로 유지되며 영역에 꽉 차는지 확인
- [ ] 서명/텍스트 저장 및 표시가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 서명 입력 시 펜 선 굵기를 더 가늘게 조정하여 세밀한 필기감을 제공합니다.
* **새 기능**
  * 텍스트 입력 모달의 렌더링을 단일 행 맞춤으로 변경했습니다. 입력 텍스트가 가로 영역에 맞도록 글꼴 크기를 자동 축소하고, 텍스트를 가로·세로 중앙에 정렬해 보기가 편해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->