### PR TITLE
fix: 텍스트 입력 폰트 굵기 및 크기 조정

### DIFF
--- a/components/text-input-modal.tsx
+++ b/components/text-input-modal.tsx
@@ -83,14 +83,17 @@ export default function TextInputModal({
 
     // Dynamic font sizing: single line, fit to fill the width
     let fontSize = maxHeight; // start with max height as upper bound
-    ctx.font = `bold ${fontSize}px ${fontFamily}`;
+    ctx.font = `${fontSize}px ${fontFamily}`;
     while (fontSize > 20 && ctx.measureText(inputText).width > maxWidth) {
       fontSize -= 4;
-      ctx.font = `bold ${fontSize}px ${fontFamily}`;
+      ctx.font = `${fontSize}px ${fontFamily}`;
     }
 
+    // Reduce font size by 30% for thinner strokes matching signature pen width
+    fontSize = Math.round(fontSize * 0.7);
+
     ctx.clearRect(0, 0, logicalWidth, logicalHeight);
-    ctx.font = `bold ${fontSize}px ${fontFamily}`;
+    ctx.font = `${fontSize}px ${fontFamily}`;
     ctx.fillStyle = "#000000";
     ctx.textBaseline = "middle";
 


### PR DESCRIPTION
## Summary
- 텍스트 입력 모달의 `bold` 제거하여 서명 캔버스 펜 굵기와 일치시킴
- 폰트 크기 30% 축소 (`fontSize * 0.7`) 적용

## Test plan
- [x] 텍스트 입력 시 이전보다 얇고 작은 글씨로 렌더링되는지 확인
- [x] 서명 펜 굵기와 시각적으로 유사한지 확인
- [x] 텍스트 저장 및 문서 표시가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **스타일**
  * 텍스트 입력 모달의 폰트 렌더링을 조정했습니다. Bold 스타일을 제거하고 폰트 크기를 30% 축소하여 더 얇은 획을 표현합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->