### PR TITLE
fix: 멀티이미지 업로드 시 현재 이미지만 개별 삭제 + 확인 모달

### DIFF
--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -310,6 +310,10 @@ export default function DocumentUpload() {
   const handleRemoveImage = () => {
     const indexToRemove = currentIndex;
 
+    // Clear selection state to prevent stale selector on next image
+    setIsSelecting(false);
+    setPdfPageImageForSelector(null);
+
     // If only one image, clear everything
     if (images.length <= 1) {
       handleClearDocument();
@@ -655,6 +659,7 @@ export default function DocumentUpload() {
               <Button
                 variant="outline"
                 onClick={() => setShowDeleteImageModal(true)}
+                disabled={isLoading || isSelecting}
                 className="text-destructive border-destructive/30 hover:text-destructive hover:bg-destructive/5"
               >
                 <Trash2 className="mr-1.5 h-4 w-4" />
@@ -664,6 +669,7 @@ export default function DocumentUpload() {
                 <Button
                   variant="outline"
                   onClick={() => setShowClearAllModal(true)}
+                  disabled={isLoading || isSelecting}
                   className="text-muted-foreground"
                   size="sm"
                 >
@@ -1143,7 +1149,7 @@ export default function DocumentUpload() {
             <Button variant="outline" onClick={() => setShowDeleteImageModal(false)}>
               {t("upload.deleteImageCancel")}
             </Button>
-            <Button variant="destructive" onClick={handleRemoveImage}>
+            <Button variant="destructive" onClick={handleRemoveImage} disabled={isLoading}>
               {t("upload.deleteImageDelete")}
             </Button>
           </DialogFooter>
@@ -1166,7 +1172,7 @@ export default function DocumentUpload() {
             <Button variant="outline" onClick={() => setShowClearAllModal(false)}>
               {t("upload.deleteImageCancel")}
             </Button>
-            <Button variant="destructive" onClick={() => { setShowClearAllModal(false); handleClearDocument(); }}>
+            <Button variant="destructive" disabled={isLoading} onClick={() => { setShowClearAllModal(false); handleClearDocument(); }}>
               {t("upload.clearAll")}
             </Button>
           </DialogFooter>

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -678,14 +678,16 @@ export default function DocumentUpload() {
               )}
             </div>
             <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={isLoading || isSelecting || images.some((img) => img.isPdf)}
-              >
-                <Upload className="mr-1.5 h-4 w-4" />
-                {t("upload.addMore")}
-              </Button>
+              {!images.some((img) => img.isPdf) && (
+                <Button
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isLoading || isSelecting}
+                >
+                  <Upload className="mr-1.5 h-4 w-4" />
+                  {t("upload.addMore")}
+                </Button>
+              )}
               <Button
                 onClick={handleSaveDocument}
                 disabled={

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -552,6 +552,15 @@ export default function DocumentUpload() {
 
   return (
     <div className="space-y-8">
+      {/* Hidden file input shared across initial and editing views */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept={uploadMode === 'pdf' ? ".pdf,application/pdf" : "image/*"}
+        multiple={uploadMode === 'image'}
+        className="hidden"
+        onChange={handleFileChange}
+      />
       {error && images.length === 0 && (
         <div className="p-3 bg-red-50 border border-red-200 rounded-md text-red-600 text-sm">
           {error}
@@ -634,14 +643,6 @@ export default function DocumentUpload() {
                   <Upload className="mr-2 h-4 w-4" />
                   {t("upload.button")}
                 </Button>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept={uploadMode === 'pdf' ? ".pdf,application/pdf" : "image/*"}
-                  multiple={uploadMode === 'image'}
-                  className="hidden"
-                  onChange={handleFileChange}
-                />
               </div>
             </CardContent>
           </Card>
@@ -670,14 +671,24 @@ export default function DocumentUpload() {
                 </Button>
               )}
             </div>
-            <Button
-              onClick={handleSaveDocument}
-              disabled={
-                totalAreasCount === 0 || isLoading || images.length === 0
-              }
-            >
-              {isLoading ? (savingProgress || t("upload.saving")) : t("upload.save")}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={isLoading || isSelecting}
+              >
+                <Upload className="mr-1.5 h-4 w-4" />
+                {t("upload.addMore")}
+              </Button>
+              <Button
+                onClick={handleSaveDocument}
+                disabled={
+                  totalAreasCount === 0 || isLoading || images.length === 0
+                }
+              >
+                {isLoading ? (savingProgress || t("upload.saving")) : t("upload.save")}
+              </Button>
+            </div>
           </div>
 
           {/* 2. File Information - per image */}

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -681,7 +681,7 @@ export default function DocumentUpload() {
               <Button
                 variant="outline"
                 onClick={() => fileInputRef.current?.click()}
-                disabled={isLoading || isSelecting}
+                disabled={isLoading || isSelecting || images.some((img) => img.isPdf)}
               >
                 <Upload className="mr-1.5 h-4 w-4" />
                 {t("upload.addMore")}

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -103,6 +103,8 @@ export default function DocumentUpload() {
 
   // Delete image confirmation modal
   const [showDeleteImageModal, setShowDeleteImageModal] = useState<boolean>(false);
+  // Clear all confirmation modal
+  const [showClearAllModal, setShowClearAllModal] = useState<boolean>(false);
 
   // Sync carousel index with state
   useEffect(() => {
@@ -660,7 +662,7 @@ export default function DocumentUpload() {
               {images.length > 1 && (
                 <Button
                   variant="outline"
-                  onClick={handleClearDocument}
+                  onClick={() => setShowClearAllModal(true)}
                   className="text-muted-foreground"
                   size="sm"
                 >
@@ -1132,6 +1134,29 @@ export default function DocumentUpload() {
             </Button>
             <Button variant="destructive" onClick={handleRemoveImage}>
               {t("upload.deleteImageDelete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Clear All Confirmation Modal */}
+      <Dialog open={showClearAllModal} onOpenChange={setShowClearAllModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-yellow-500" />
+              {t("upload.clearAllTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("upload.clearAllConfirm").replace("{count}", String(images.length))}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="outline" onClick={() => setShowClearAllModal(false)}>
+              {t("upload.deleteImageCancel")}
+            </Button>
+            <Button variant="destructive" onClick={() => { setShowClearAllModal(false); handleClearDocument(); }}>
+              {t("upload.clearAll")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -101,6 +101,9 @@ export default function DocumentUpload() {
   const [showValidationModal, setShowValidationModal] = useState<boolean>(false);
   const [missingAreaIndices, setMissingAreaIndices] = useState<number[]>([]);
 
+  // Delete image confirmation modal
+  const [showDeleteImageModal, setShowDeleteImageModal] = useState<boolean>(false);
+
   // Sync carousel index with state
   useEffect(() => {
     if (!carouselApi) return;
@@ -300,6 +303,57 @@ export default function DocumentUpload() {
     setCurrentIndex(0);
     setCurrentPdfPage(1);
     setUploadMode('image');
+  };
+
+  const handleRemoveImage = () => {
+    const indexToRemove = currentIndex;
+
+    // If only one image, clear everything
+    if (images.length <= 1) {
+      handleClearDocument();
+      setShowDeleteImageModal(false);
+      return;
+    }
+
+    // Remove image from array
+    const newImages = images.filter((_, i) => i !== indexToRemove);
+
+    // Rebuild aliasMap with shifted indices
+    const newAliasMap = new Map<number, string>();
+    aliasMap.forEach((value, key) => {
+      if (key < indexToRemove) {
+        newAliasMap.set(key, value);
+      } else if (key > indexToRemove) {
+        newAliasMap.set(key - 1, value);
+      }
+    });
+
+    // Rebuild signatureAreasMap with shifted indices
+    const newSignatureAreasMap = new Map<number, RelativeSignatureArea[]>();
+    signatureAreasMap.forEach((value, key) => {
+      if (key < indexToRemove) {
+        newSignatureAreasMap.set(key, value);
+      } else if (key > indexToRemove) {
+        newSignatureAreasMap.set(key - 1, value);
+      }
+    });
+
+    // Adjust currentIndex
+    const newIndex = indexToRemove >= newImages.length
+      ? newImages.length - 1
+      : indexToRemove;
+
+    setImages(newImages);
+    setAliasMap(newAliasMap);
+    setSignatureAreasMap(newSignatureAreasMap);
+    setCurrentIndex(newIndex);
+    setCurrentPdfPage(1);
+    setShowDeleteImageModal(false);
+
+    // Sync carousel after state update
+    requestAnimationFrame(() => {
+      carouselApi?.scrollTo(newIndex);
+    });
   };
 
   const handleZoomIn = () => {
@@ -592,16 +646,28 @@ export default function DocumentUpload() {
         </div>
       ) : (
         <div className="space-y-4">
-          {/* 1. Clear / Save buttons */}
+          {/* 1. Delete / Clear / Save buttons */}
           <div className="flex items-center justify-between">
-            <Button
-              variant="outline"
-              onClick={handleClearDocument}
-              className="text-destructive border-destructive/30 hover:text-destructive hover:bg-destructive/5"
-            >
-              <Trash2 className="mr-1.5 h-4 w-4" />
-              {t("upload.clear")}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setShowDeleteImageModal(true)}
+                className="text-destructive border-destructive/30 hover:text-destructive hover:bg-destructive/5"
+              >
+                <Trash2 className="mr-1.5 h-4 w-4" />
+                {t("upload.clear")}
+              </Button>
+              {images.length > 1 && (
+                <Button
+                  variant="outline"
+                  onClick={handleClearDocument}
+                  className="text-muted-foreground"
+                  size="sm"
+                >
+                  {t("upload.clearAll")}
+                </Button>
+              )}
+            </div>
             <Button
               onClick={handleSaveDocument}
               disabled={
@@ -1042,6 +1108,34 @@ export default function DocumentUpload() {
           )}
         </div>
       )}
+
+      {/* Delete Image Confirmation Modal */}
+      <Dialog open={showDeleteImageModal} onOpenChange={setShowDeleteImageModal}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Trash2 className="h-5 w-5 text-destructive" />
+              {t("upload.deleteImageTitle")}
+            </DialogTitle>
+            <DialogDescription>
+              {t("upload.deleteImageConfirm")}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-2">
+            <p className="text-sm text-muted-foreground">
+              {t("upload.deleteImageFileName").replace("{fileName}", images[currentIndex]?.fileName || "")}
+            </p>
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="outline" onClick={() => setShowDeleteImageModal(false)}>
+              {t("upload.deleteImageCancel")}
+            </Button>
+            <Button variant="destructive" onClick={handleRemoveImage}>
+              {t("upload.deleteImageDelete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Validation Modal */}
       <Dialog open={showValidationModal} onOpenChange={setShowValidationModal}>

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -70,6 +70,8 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.deleteImageCancel": "취소",
     "upload.deleteImageDelete": "삭제",
     "upload.clearAll": "전체 삭제",
+    "upload.clearAllTitle": "전체 삭제",
+    "upload.clearAllConfirm": "업로드된 {count}개의 이미지를 모두 삭제하시겠습니까?",
 
     // PDF
     pdf_document: "PDF 문서",
@@ -1215,6 +1217,8 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.deleteImageCancel": "Cancel",
     "upload.deleteImageDelete": "Delete",
     "upload.clearAll": "Clear All",
+    "upload.clearAllTitle": "Clear All",
+    "upload.clearAllConfirm": "Are you sure you want to delete all {count} images?",
 
     // PDF
     pdf_document: "PDF Document",

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -64,6 +64,12 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.noSignatureAreaWarningItem": "{index}번째 이미지에 서명 영역이 없습니다.",
     "upload.goToImage": "해당 이미지로 이동",
     "upload.savingProgress": "저장 중... ({current}/{total})",
+    "upload.deleteImageTitle": "이미지 삭제",
+    "upload.deleteImageConfirm": "이 이미지를 삭제하시겠습니까?",
+    "upload.deleteImageFileName": "파일명: {fileName}",
+    "upload.deleteImageCancel": "취소",
+    "upload.deleteImageDelete": "삭제",
+    "upload.clearAll": "전체 삭제",
 
     // PDF
     pdf_document: "PDF 문서",
@@ -1203,6 +1209,12 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.noSignatureAreaWarningItem": "Image {index} has no signature area.",
     "upload.goToImage": "Go to Image",
     "upload.savingProgress": "Saving... ({current}/{total})",
+    "upload.deleteImageTitle": "Delete Image",
+    "upload.deleteImageConfirm": "Are you sure you want to delete this image?",
+    "upload.deleteImageFileName": "File: {fileName}",
+    "upload.deleteImageCancel": "Cancel",
+    "upload.deleteImageDelete": "Delete",
+    "upload.clearAll": "Clear All",
 
     // PDF
     pdf_document: "PDF Document",

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -72,6 +72,7 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.clearAll": "전체 삭제",
     "upload.clearAllTitle": "전체 삭제",
     "upload.clearAllConfirm": "업로드된 {count}개의 이미지를 모두 삭제하시겠습니까?",
+    "upload.addMore": "문서 추가",
 
     // PDF
     pdf_document: "PDF 문서",
@@ -1219,6 +1220,7 @@ const translations: Record<Language, Record<string, string>> = {
     "upload.clearAll": "Clear All",
     "upload.clearAllTitle": "Clear All",
     "upload.clearAllConfirm": "Are you sure you want to delete all {count} images?",
+    "upload.addMore": "Add Document",
 
     // PDF
     pdf_document: "PDF Document",


### PR DESCRIPTION
## Summary
- 멀티이미지 업로드에서 삭제 버튼 클릭 시 모든 이미지가 삭제되던 문제 수정
- 현재 보고 있는 이미지만 개별 삭제되도록 `handleRemoveImage` 함수 추가
- 삭제 전 확인 모달(Dialog) 표시 (파일명 포함)
- 이미지가 여러 개일 때 "전체 삭제" 버튼 별도 표시
- `aliasMap`, `signatureAreasMap` 인덱스 재정렬 로직으로 데이터 정합성 보장

## Test plan
- [x] 이미지 1개 업로드 후 삭제 버튼 → 확인 모달 표시 → 삭제 시 초기 상태로 복귀
- [x] 이미지 3개 업로드 후 2번째 이미지에서 삭제 → 해당 이미지만 제거, 나머지 유지
- [x] 삭제 후 서명 영역/별칭이 올바른 이미지에 매핑되는지 확인
- [x] 확인 모달에서 "취소" 클릭 시 아무 변화 없음
- [x] "전체 삭제" 버튼이 이미지 2개 이상일 때만 표시되는지 확인
- [x] 한국어/영어 번역 모두 정상 표시
- [x] 문서 추가 버튼으로 추가문서 업로드되는지 확인
- [x] pdf 업로드 모드일 경우 문서 추가 버튼 미노출

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이미지 삭제 및 전체 삭제 확인 대화상자 추가
  * 확인 대화상자에 현재 파일명 표시
  * 숨겨진 파일 입력으로 추가 업로드 지원

* **개선 사항**
  * 삭제 시 뷰와 인덱스 자동 갱신으로 일관된 UX 제공
  * 버튼/액션 배열을 재구성하여 Add More·Save·Delete·Clear All 조작 정리

* **국제화**
  * 한국어·영어 문구 추가로 삭제 관련 UI 번역 지원 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->