### PR TITLE
feat: PDF 업로드 시 JPEG 프리뷰 생성으로 iOS 호환성 확보

### DIFF
--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   updateSignatureAreas,
   getSignedDocumentUrls,
   deleteDocument,
+  getPreviewImageSignedUrls,
 } from "@/app/actions/document-actions";
 import AreaSelector from "@/components/area-selector";
 import DeleteDocumentModal from "@/components/delete-document-modal";
@@ -85,6 +86,7 @@ export default function DocumentDetailComponent({
   const [currentPdfPage, setCurrentPdfPage] = useState<number>(1);
   const [pdfPageDimensions, setPdfPageDimensions] = useState<PdfPageDimensions | null>(null);
   const [pdfPageImageForSelector, setPdfPageImageForSelector] = useState<string | null>(null);
+  const [previewImageUrls, setPreviewImageUrls] = useState<(string | null)[]>([]);
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -347,6 +349,17 @@ export default function DocumentDetailComponent({
     document.signed_file_url,
     document.signed_pdf_url,
   ]);
+
+  // Load PDF preview images for viewing
+  useEffect(() => {
+    if (isPdf && totalPages > 0) {
+      getPreviewImageSignedUrls(documentData.id, totalPages).then((result) => {
+        if (result.urls && result.urls.length > 0) {
+          setPreviewImageUrls(result.urls);
+        }
+      }).catch(() => {});
+    }
+  }, [isPdf, totalPages, documentData.id]);
 
   // Force re-render when image loads to ensure signature areas display correctly
   useEffect(() => {
@@ -864,12 +877,22 @@ export default function DocumentDetailComponent({
                     <p className="text-gray-500">{t("documentDetail.loading")}</p>
                   </div>
                 ) : shouldRenderAsPdf ? (
-                  <PdfPageRenderer
-                    pdfUrl={isCompleted && signedDocumentPreviewUrl ? signedDocumentPreviewUrl : (documentUrl || "")}
-                    currentPage={currentPdfPage}
-                    zoomLevel={1}
-                    onPageDimensionsChange={setPdfPageDimensions}
-                  />
+                  previewImageUrls.length > 0 && previewImageUrls[currentPdfPage - 1] && !isCompleted ? (
+                    <img
+                      src={previewImageUrls[currentPdfPage - 1]!}
+                      alt={`Page ${currentPdfPage}`}
+                      className="w-full h-auto object-contain block"
+                      draggable="false"
+                      style={{ userSelect: "none", WebkitUserSelect: "none" }}
+                    />
+                  ) : (
+                    <PdfPageRenderer
+                      pdfUrl={isCompleted && signedDocumentPreviewUrl ? signedDocumentPreviewUrl : (documentUrl || "")}
+                      currentPage={currentPdfPage}
+                      zoomLevel={1}
+                      onPageDimensionsChange={setPdfPageDimensions}
+                    />
+                  )
                 ) : (
                   <img
                     src={displayImageUrl}

--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -7,6 +7,7 @@ import {
   getDocumentFileSignedUrl,
   markDocumentCompleted,
   createSignedDocumentUploadUrl,
+  getPreviewImageSignedUrls,
 } from "@/app/actions/document-actions";
 import LanguageSelector from "@/components/language-selector";
 import SignatureModal from "@/components/signature-modal";
@@ -103,6 +104,8 @@ export default function SignSingleDocument({
   const totalPages = (documentData as any).page_count || 1;
   const [currentPdfPage, setCurrentPdfPage] = useState<number>(1);
   const [pdfPageDimensions, setPdfPageDimensions] = useState<PdfPageDimensions | null>(null);
+  const [previewImageUrls, setPreviewImageUrls] = useState<(string | null)[]>([]);
+  const [previewsLoaded, setPreviewsLoaded] = useState<boolean>(false);
 
   const handleAreaClick = (areaIndex: number) => {
     setSelectedArea(areaIndex);
@@ -589,6 +592,20 @@ export default function SignSingleDocument({
     }
   }, [isPasswordVerified, documentSignedUrl]);
 
+  // Load PDF preview images
+  useEffect(() => {
+    if (isPdf && isPasswordVerified && totalPages > 0) {
+      getPreviewImageSignedUrls(documentData.id, totalPages).then((result) => {
+        if (result.urls && result.urls.length > 0) {
+          setPreviewImageUrls(result.urls);
+        }
+        setPreviewsLoaded(true);
+      }).catch(() => {
+        setPreviewsLoaded(true);
+      });
+    }
+  }, [isPdf, isPasswordVerified, totalPages, documentData.id]);
+
   // Force re-render when image loads to ensure signature areas display correctly
   useEffect(() => {
     if (imageLoaded && documentContainerRef.current) {
@@ -819,13 +836,24 @@ export default function SignSingleDocument({
               }}
             >
               {isPdf ? (
-                <PdfPageRenderer
-                  pdfUrl={documentSignedUrl || documentData.file_url}
-                  currentPage={currentPdfPage}
-                  zoomLevel={1}
-                  onPageDimensionsChange={setPdfPageDimensions}
-                  onLoadError={(error) => setError(error)}
-                />
+                previewImageUrls.length > 0 && previewImageUrls[currentPdfPage - 1] ? (
+                  <img
+                    src={previewImageUrls[currentPdfPage - 1]!}
+                    alt={`Page ${currentPdfPage}`}
+                    className="w-full h-auto object-contain block"
+                    draggable="false"
+                    style={{ userSelect: "none", WebkitUserSelect: "none" }}
+                    onLoad={() => setImageLoaded(true)}
+                  />
+                ) : (
+                  <PdfPageRenderer
+                    pdfUrl={documentSignedUrl || documentData.file_url}
+                    currentPage={currentPdfPage}
+                    zoomLevel={1}
+                    onPageDimensionsChange={setPdfPageDimensions}
+                    onLoadError={(error) => setError(error)}
+                  />
+                )
               ) : (
                 <img
                   src={documentSignedUrl || documentData.file_url}

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -1679,3 +1679,92 @@ export async function updateDocumentAlias(
     return { error: "An unexpected error occurred" };
   }
 }
+
+/**
+ * Create presigned upload URLs for PDF preview images
+ * Called after PDF upload to generate JPEG preview images for each page
+ */
+export async function createPreviewUploadUrls(
+  documentId: string,
+  pageCount: number
+): Promise<{
+  uploadUrls?: { page: number; url: string; path: string }[];
+  error?: string;
+}> {
+  try {
+    const supabaseService = createServiceSupabase();
+
+    const urls: { page: number; url: string; path: string }[] = [];
+
+    for (let i = 0; i < pageCount; i++) {
+      const filePath = `previews/${documentId}/page-${i}.jpg`;
+
+      // Remove existing file if any
+      await supabaseService.storage
+        .from("documents")
+        .remove([filePath]);
+
+      const { data, error } = await supabaseService.storage
+        .from("documents")
+        .createSignedUploadUrl(filePath);
+
+      if (error || !data) {
+        console.error(`Failed to create upload URL for page ${i}:`, error);
+        return { error: `Failed to create upload URL for page ${i}` };
+      }
+
+      urls.push({
+        page: i,
+        url: data.signedUrl,
+        path: filePath,
+      });
+    }
+
+    return { uploadUrls: urls };
+  } catch (error) {
+    console.error("Create preview upload URLs error:", error);
+    return { error: "An unexpected error occurred" };
+  }
+}
+
+/**
+ * Get signed URLs for PDF preview images
+ * Used by sign page and document detail to load JPEG previews instead of rendering PDF client-side
+ */
+export async function getPreviewImageSignedUrls(
+  documentId: string,
+  pageCount: number
+): Promise<{
+  urls?: (string | null)[];
+  error?: string;
+}> {
+  try {
+    const supabaseService = createServiceSupabase();
+
+    const urls: (string | null)[] = [];
+
+    for (let i = 0; i < pageCount; i++) {
+      const filePath = `previews/${documentId}/page-${i}.jpg`;
+
+      const { data, error } = await supabaseService.storage
+        .from("documents")
+        .createSignedUrl(filePath, 3600);
+
+      if (error || !data) {
+        urls.push(null);
+      } else {
+        urls.push(data.signedUrl);
+      }
+    }
+
+    // If no valid URLs found, previews don't exist
+    if (urls.every(u => u === null)) {
+      return { urls: [], error: "No preview images found" };
+    }
+
+    return { urls };
+  } catch (error) {
+    console.error("Get preview image signed URLs error:", error);
+    return { error: "An unexpected error occurred" };
+  }
+}

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -27,6 +27,7 @@ import AreaSelector from "@/components/area-selector";
 import {
   uploadDocument,
   createSignatureAreas,
+  createPreviewUploadUrls,
 } from "@/app/actions/document-actions";
 import { canUploadPdf } from "@/app/actions/subscription-actions";
 import { useLanguage } from "@/contexts/language-context";
@@ -449,6 +450,61 @@ export default function DocumentUpload() {
     carouselApi?.scrollTo(index);
   }, [carouselApi]);
 
+  // Generate JPEG preview images for PDF pages
+  const generatePdfPreviews = async (file: File, documentId: string, pageCount: number) => {
+    try {
+      const pdfjsLib = await import("pdfjs-dist");
+      if (typeof window !== "undefined") {
+        pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+      }
+
+      const arrayBuffer = await file.arrayBuffer();
+      const pdf = await pdfjsLib.getDocument({ data: new Uint8Array(arrayBuffer) }).promise;
+
+      // Get presigned upload URLs
+      const urlResult = await createPreviewUploadUrls(documentId, pageCount);
+      if (urlResult.error || !urlResult.uploadUrls) {
+        console.error("Failed to get preview upload URLs:", urlResult.error);
+        return;
+      }
+
+      // Render each page and upload
+      for (let i = 0; i < pageCount; i++) {
+        const page = await pdf.getPage(i + 1); // pdf.js pages are 1-indexed
+        const viewport = page.getViewport({ scale: 2 }); // 2x for good quality
+
+        const canvas = document.createElement("canvas");
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) continue;
+
+        await page.render({ canvasContext: ctx, viewport }).promise;
+
+        // Convert to JPEG blob
+        const blob = await new Promise<Blob | null>((resolve) => {
+          canvas.toBlob((b) => resolve(b), "image/jpeg", 0.85);
+        });
+        if (!blob) continue;
+
+        // Upload to presigned URL
+        const uploadInfo = urlResult.uploadUrls.find((u) => u.page === i);
+        if (!uploadInfo) continue;
+
+        await fetch(uploadInfo.url, {
+          method: "PUT",
+          body: blob,
+          headers: { "Content-Type": "image/jpeg" },
+        });
+      }
+
+      pdf.destroy();
+    } catch (err) {
+      console.error("Failed to generate PDF previews:", err);
+      // Non-fatal: previews are optional, PDF still works on modern browsers
+    }
+  };
+
   const handleSaveDocument = async () => {
     if (images.length === 0) {
       setError("Please upload at least one document");
@@ -526,6 +582,12 @@ export default function DocumentUpload() {
         if (areasResult.error) {
           setError(areasResult.error);
           return;
+        }
+
+        // Step 3: Generate JPEG preview images for PDF documents (non-blocking)
+        if (img.file.type === "application/pdf") {
+          const pageCount = (uploadResult.document as any).page_count || 1;
+          await generatePdfPreviews(img.file, uploadResult.document.id, pageCount);
         }
       }
 


### PR DESCRIPTION
## Summary
- PDF 업로드 시 클라이언트에서 페이지별 JPEG 프리뷰 이미지 생성 (quality 85%, 2x 해상도)
- 서명 화면/문서 상세에서 `<img>` 태그로 표시 → 모든 iOS 버전에서 동작
- 프리뷰 없는 기존 문서는 PdfPageRenderer fallback 유지
- 스토리지 영향: 페이지당 ~150-250KB (JPEG), 10페이지 PDF 기준 ~1.5-2.5MB

## 변경 파일
- `document-actions.ts`: `createPreviewUploadUrls`, `getPreviewImageSignedUrls` 서버 액션 추가
- `document-upload.tsx`: PDF 업로드 후 `generatePdfPreviews()` 호출
- `SignSingleDocument.tsx`: 프리뷰 이미지 우선 로드, fallback to PdfPageRenderer
- `DocumentDetailPage.tsx`: 동일 전략 (완료 문서는 서명 PDF 유지)

## Test plan
- [ ] 새 PDF 업로드 후 Supabase Storage에 previews/ 디렉토리 생성 확인
- [ ] 서명 화면에서 JPEG 이미지로 PDF 표시 확인
- [ ] 문서 상세에서 JPEG 프리뷰 표시 확인
- [ ] 프리뷰 없는 기존 PDF 문서에서 PdfPageRenderer fallback 동작 확인
- [ ] 이미지 문서 업로드/서명 기존 동작 정상 확인
- [ ] 멀티페이지 PDF 페이지 네비게이션 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- PDF 문서 페이지를 미리보기 이미지로 표시하는 기능 추가
- 문서 업로드 시 PDF 페이지별 미리보기 이미지 자동 생성
- 미리보기 이미지 로딩 불가 시 기존 PDF 렌더링 방식으로 폴백
- 문서 상세 보기 및 서명 페이지에서 미리보기 이미지 지원

<!-- end of auto-generated comment: release notes by coderabbit.ai -->