### PR TITLE
fix: pdf.js worker가 인증 미들웨어에 막혀 서명 페이지 PDF 로딩 실패하는 문제 해결

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -14,9 +14,9 @@ export const config = {
      * - favicon.ico (favicon file)
      * - sitemap.xml (SEO sitemap)
      * - robots.txt (SEO robots)
-     * - .*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$ (image files)
+     * - .*\\.(?:ico|png|svg|jpg|jpeg|gif|webp|mjs|js|wasm)$ (image/static asset files)
      * - api/webhook (Paddle webhook endpoint)
      */
-    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|api/webhook|.*\\.(?:ico|png|svg|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|api/webhook|.*\\.(?:ico|png|svg|jpg|jpeg|gif|webp|mjs|js|wasm)$).*)",
   ],
 };


### PR DESCRIPTION
## 문제

서명 페이지(`/sign/[shortUrl]`)에서 PDF 문서가 로드되지 않음.

콘솔 에러:
```
Failed to load module script: ... MIME type of "text/html"
PDF load error: Error: Setting up fake worker failed:
"Failed to fetch dynamically imported module: https://www.seuk-seuk.com/pdf.worker.min.mjs".
```

## 원인

PDF나 worker 파일 자체 문제가 아니라 **인증 미들웨어**가 원인이었음.

- `89618f9`에서 pdf.js worker를 CDN → 로컬 정적 파일(`/pdf.worker.min.mjs`)로 변경
- `middleware.ts`의 `matcher`는 이미지 확장자(`ico|png|svg|...`)만 제외하고 **`.mjs`는 제외하지 않음**
- 결과: `/pdf.worker.min.mjs` 요청이 미들웨어를 통과 → 미인증 사용자라 `307 → /login` 리다이렉트
- pdf.js가 worker 대신 로그인 페이지 HTML(`text/html`)을 받아 `Setting up fake worker failed`로 실패

프로덕션에서 직접 확인한 응답:
```
HTTP/2 307
location: /login
Redirecting...
```

## 해결

`matcher` 제외 확장자에 `mjs|js|wasm`을 추가해 정적 worker 에셋이 미들웨어를 우회하도록 수정.

## 검증

정규식 테스트로 정적 에셋은 제외되고 페이지 경로는 그대로 통과함을 확인:
```
EXCLUDED   /pdf.worker.min.mjs
MIDDLEWARE /sign/abc123
MIDDLEWARE /login
MIDDLEWARE /dashboard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 정적 자산 및 스크립트 파일 요청에 대한 미들웨어 처리 범위를 최적화하여 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->