### PR TITLE
feat: 서명자 서명완료 문서 다운로드 버튼 추가

### DIFF
--- a/app/(sign)/sign/[id]/components/SignDocumentList.tsx
+++ b/app/(sign)/sign/[id]/components/SignDocumentList.tsx
@@ -26,6 +26,7 @@ interface SignDocumentListProps {
   publicationData: PublicationWithDocuments;
   requiresPassword: boolean;
   isPasswordVerified: boolean;
+  verifiedPassword?: string | null;
   onPasswordVerified: (password: string) => void;
   onSelectDocument: (documentId: string) => void;
 }
@@ -34,6 +35,7 @@ export default function SignDocumentList({
   publicationData,
   requiresPassword,
   isPasswordVerified,
+  verifiedPassword,
   onPasswordVerified,
   onSelectDocument,
 }: SignDocumentListProps) {
@@ -151,7 +153,7 @@ export default function SignDocumentList({
                       <SignedDocumentDownloadButton
                         shortUrl={publicationData.short_url}
                         documentId={doc.id}
-                        password={password}
+                        password={verifiedPassword ?? password}
                       />
                     </div>
                   ))}

--- a/app/(sign)/sign/[id]/components/SignDocumentList.tsx
+++ b/app/(sign)/sign/[id]/components/SignDocumentList.tsx
@@ -2,7 +2,7 @@
 
 import { verifyPublicationPassword } from "@/app/actions/publication-actions";
 import LanguageSelector from "@/components/language-selector";
-import SignedDocumentDownloadButton from "./SignedDocumentDownloadButton";
+import SignedDocumentBundleButton from "./SignedDocumentBundleButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -143,29 +143,14 @@ export default function SignDocumentList({
                     {t("sign.completed.status")}
                   </p>
                 </div>
-                {(() => {
-                  const completedDocs =
-                    publicationData.documents?.filter(
-                      (doc) => doc.status === "completed"
-                    ) ?? [];
-                  // Show per-document name only when there are multiple downloads;
-                  // for a single document the name is already shown above.
-                  const showDocName = completedDocs.length > 1;
-                  return completedDocs.map((doc) => (
-                    <div key={doc.id} className="space-y-1">
-                      {showDocName && (
-                        <p className="text-sm text-center text-gray-600">
-                          {doc.alias || doc.filename}
-                        </p>
-                      )}
-                      <SignedDocumentDownloadButton
-                        shortUrl={publicationData.short_url}
-                        documentId={doc.id}
-                        password={verifiedPassword ?? password}
-                      />
-                    </div>
-                  ));
-                })()}
+                {publicationData.documents?.some(
+                  (doc) => doc.status === "completed"
+                ) && (
+                  <SignedDocumentBundleButton
+                    shortUrl={publicationData.short_url}
+                    password={verifiedPassword ?? password}
+                  />
+                )}
               </CardContent>
             </Card>
           </div>

--- a/app/(sign)/sign/[id]/components/SignDocumentList.tsx
+++ b/app/(sign)/sign/[id]/components/SignDocumentList.tsx
@@ -25,7 +25,7 @@ interface SignDocumentListProps {
   publicationData: PublicationWithDocuments;
   requiresPassword: boolean;
   isPasswordVerified: boolean;
-  onPasswordVerified: () => void;
+  onPasswordVerified: (password: string) => void;
   onSelectDocument: (documentId: string) => void;
 }
 
@@ -68,7 +68,7 @@ export default function SignDocumentList({
       }
 
       if (result.isValid) {
-        onPasswordVerified();
+        onPasswordVerified(password);
       } else {
         setError(t("sign.password.incorrect"));
       }

--- a/app/(sign)/sign/[id]/components/SignDocumentList.tsx
+++ b/app/(sign)/sign/[id]/components/SignDocumentList.tsx
@@ -2,6 +2,7 @@
 
 import { verifyPublicationPassword } from "@/app/actions/publication-actions";
 import LanguageSelector from "@/components/language-selector";
+import SignedDocumentDownloadButton from "./SignedDocumentDownloadButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -96,8 +97,10 @@ export default function SignDocumentList({
     return { completed, total };
   };
 
-  // Show completed document screen if publication is completed
-  if (isCompleted) {
+  // Show completed document screen if publication is completed.
+  // For password-protected publications, defer to the password gate below first
+  // so the entered password is available for signed-document downloads.
+  if (isCompleted && (!requiresPassword || isPasswordVerified)) {
     return (
       <div className="flex flex-col min-h-screen bg-background">
         {/* Header with logo */}
@@ -138,6 +141,20 @@ export default function SignDocumentList({
                     {t("sign.completed.status")}
                   </p>
                 </div>
+                {publicationData.documents
+                  ?.filter((doc) => doc.status === "completed")
+                  .map((doc) => (
+                    <div key={doc.id} className="space-y-1">
+                      <p className="text-sm text-center text-gray-600">
+                        {doc.alias || doc.filename}
+                      </p>
+                      <SignedDocumentDownloadButton
+                        shortUrl={publicationData.short_url}
+                        documentId={doc.id}
+                        password={password}
+                      />
+                    </div>
+                  ))}
               </CardContent>
             </Card>
           </div>

--- a/app/(sign)/sign/[id]/components/SignDocumentList.tsx
+++ b/app/(sign)/sign/[id]/components/SignDocumentList.tsx
@@ -143,20 +143,29 @@ export default function SignDocumentList({
                     {t("sign.completed.status")}
                   </p>
                 </div>
-                {publicationData.documents
-                  ?.filter((doc) => doc.status === "completed")
-                  .map((doc) => (
+                {(() => {
+                  const completedDocs =
+                    publicationData.documents?.filter(
+                      (doc) => doc.status === "completed"
+                    ) ?? [];
+                  // Show per-document name only when there are multiple downloads;
+                  // for a single document the name is already shown above.
+                  const showDocName = completedDocs.length > 1;
+                  return completedDocs.map((doc) => (
                     <div key={doc.id} className="space-y-1">
-                      <p className="text-sm text-center text-gray-600">
-                        {doc.alias || doc.filename}
-                      </p>
+                      {showDocName && (
+                        <p className="text-sm text-center text-gray-600">
+                          {doc.alias || doc.filename}
+                        </p>
+                      )}
                       <SignedDocumentDownloadButton
                         shortUrl={publicationData.short_url}
                         documentId={doc.id}
                         password={verifiedPassword ?? password}
                       />
                     </div>
-                  ))}
+                  ));
+                })()}
               </CardContent>
             </Card>
           </div>

--- a/app/(sign)/sign/[id]/components/SignPageContainer.tsx
+++ b/app/(sign)/sign/[id]/components/SignPageContainer.tsx
@@ -65,6 +65,7 @@ export default function SignPageContainer({
         publicationData={publicationData}
         requiresPassword={requiresPassword}
         isPasswordVerified={isPasswordVerified}
+        verifiedPassword={verifiedPassword}
         onPasswordVerified={handlePasswordVerified}
         onSelectDocument={handleDocumentSelect}
       />

--- a/app/(sign)/sign/[id]/components/SignPageContainer.tsx
+++ b/app/(sign)/sign/[id]/components/SignPageContainer.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import type { PublicationWithDocuments } from "@/lib/supabase/database.types";
 import SignDocumentList from "./SignDocumentList";
 import SignSingleDocument from "./SignSingleDocument";
+import SignedDocumentDownloadButton from "./SignedDocumentDownloadButton";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CheckCircle, FileSignature, ArrowLeft } from "lucide-react";
@@ -28,7 +29,9 @@ export default function SignPageContainer({
   const [currentView, setCurrentView] = useState<View>("list");
   const [selectedDocumentId, setSelectedDocumentId] = useState<string | null>(null);
   const [completedDocumentName, setCompletedDocumentName] = useState<string>("");
+  const [completedDocumentId, setCompletedDocumentId] = useState<string | null>(null);
   const [isPasswordVerified, setIsPasswordVerified] = useState<boolean>(!requiresPassword);
+  const [verifiedPassword, setVerifiedPassword] = useState<string | null>(null);
 
   const handleDocumentSelect = (documentId: string) => {
     setSelectedDocumentId(documentId);
@@ -42,12 +45,14 @@ export default function SignPageContainer({
     setSelectedDocumentId(null);
   };
 
-  const handlePasswordVerified = () => {
+  const handlePasswordVerified = (password: string) => {
     setIsPasswordVerified(true);
+    setVerifiedPassword(password);
   };
 
-  const handleDocumentComplete = (documentName: string) => {
+  const handleDocumentComplete = (documentName: string, documentId: string) => {
     setCompletedDocumentName(documentName);
+    setCompletedDocumentId(documentId);
     setCurrentView("completed");
     // Refresh data immediately to get updated publication status
     router.refresh();
@@ -84,6 +89,7 @@ export default function SignPageContainer({
         documentData={selectedDocument}
         requiresPassword={requiresPassword}
         isPasswordVerified={isPasswordVerified}
+        verifiedPassword={verifiedPassword}
         onBack={handleBackToList}
         onComplete={handleDocumentComplete}
       />
@@ -132,6 +138,13 @@ export default function SignPageContainer({
                     {t("sign.completed.status")}
                   </p>
                 </div>
+                {completedDocumentId && (
+                  <SignedDocumentDownloadButton
+                    shortUrl={publicationData.short_url}
+                    documentId={completedDocumentId}
+                    password={verifiedPassword}
+                  />
+                )}
                 {/* Hide back button if publication is already completed */}
                 {publicationData.status !== "completed" && (
                   <Button

--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -9,6 +9,7 @@ import {
   createSignedDocumentUploadUrl,
 } from "@/app/actions/document-actions";
 import LanguageSelector from "@/components/language-selector";
+import SignedDocumentDownloadButton from "./SignedDocumentDownloadButton";
 import SignatureModal from "@/components/signature-modal";
 import TextInputModal from "@/components/text-input-modal";
 import { Button } from "@/components/ui/button";
@@ -53,8 +54,9 @@ interface SignSingleDocumentProps {
   documentData: ClientDocument & { signatures: Signature[] };
   requiresPassword: boolean;
   isPasswordVerified: boolean;
+  verifiedPassword?: string | null;
   onBack: () => void;
-  onComplete: (documentName: string) => void;
+  onComplete: (documentName: string, documentId: string) => void;
 }
 
 export default function SignSingleDocument({
@@ -62,6 +64,7 @@ export default function SignSingleDocument({
   documentData,
   requiresPassword,
   isPasswordVerified,
+  verifiedPassword,
   onBack,
   onComplete,
 }: SignSingleDocumentProps) {
@@ -213,7 +216,7 @@ export default function SignSingleDocument({
         setIsGenerating(false);
         setGeneratingProgress("");
         setProgressValue(0);
-        onComplete(documentData.alias || documentData.filename);
+        onComplete(documentData.alias || documentData.filename, documentData.id);
       } else {
         // === Image Document: Existing client-side canvas compositing ===
         setProgressValue(10);
@@ -408,7 +411,7 @@ export default function SignSingleDocument({
         setIsGenerating(false);
         setGeneratingProgress("");
         setProgressValue(0);
-        onComplete(documentData.alias || documentData.filename);
+        onComplete(documentData.alias || documentData.filename, documentData.id);
       }
     } catch (err) {
       console.error("Error generating signed document:", err);
@@ -642,6 +645,13 @@ export default function SignSingleDocument({
                     {t("sign.completed.status")}
                   </p>
                 </div>
+                {isDocumentCompleted && (
+                  <SignedDocumentDownloadButton
+                    shortUrl={publicationData.short_url}
+                    documentId={documentData.id}
+                    password={verifiedPassword}
+                  />
+                )}
               </CardContent>
             </Card>
           </div>

--- a/app/(sign)/sign/[id]/components/SignedDocumentBundleButton.tsx
+++ b/app/(sign)/sign/[id]/components/SignedDocumentBundleButton.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Download, Loader2 } from "lucide-react";
+import { useLanguage } from "@/contexts/language-context";
+import { getSignedDocumentBundleForSigner } from "@/app/actions/document-actions";
+
+interface SignedDocumentBundleButtonProps {
+  shortUrl: string;
+  password?: string | null;
+}
+
+function triggerDownload(href: string, downloadName?: string) {
+  const link = document.createElement("a");
+  link.href = href;
+  if (downloadName) link.download = downloadName;
+  link.rel = "noopener noreferrer";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export default function SignedDocumentBundleButton({
+  shortUrl,
+  password,
+}: SignedDocumentBundleButtonProps) {
+  const { t } = useLanguage();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDownload = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await getSignedDocumentBundleForSigner(shortUrl, password);
+
+      if (result.error) {
+        setError(t("sign.completed.downloadError"));
+        return;
+      }
+
+      // Single document: direct signed URL (carries download disposition)
+      if (result.downloadUrl) {
+        triggerDownload(result.downloadUrl);
+        return;
+      }
+
+      // Multiple documents: zip archive delivered as base64
+      if (result.zipBase64) {
+        const byteString = atob(result.zipBase64);
+        const bytes = new Uint8Array(byteString.length);
+        for (let i = 0; i < byteString.length; i++) {
+          bytes[i] = byteString.charCodeAt(i);
+        }
+        const blob = new Blob([bytes], { type: "application/zip" });
+        const objectUrl = URL.createObjectURL(blob);
+        triggerDownload(objectUrl, result.filename || "서명문서.zip");
+        // Defer revoke so the browser can start reading the blob URL.
+        setTimeout(() => URL.revokeObjectURL(objectUrl), 10000);
+        return;
+      }
+
+      setError(t("sign.completed.downloadError"));
+    } catch {
+      setError(t("sign.completed.downloadError"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={handleDownload} disabled={isLoading} className="w-full">
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            {t("sign.completed.downloadLoading")}
+          </>
+        ) : (
+          <>
+            <Download className="mr-2 h-4 w-4" />
+            {t("sign.completed.download")}
+          </>
+        )}
+      </Button>
+      {error && <p className="text-sm text-red-500 text-center">{error}</p>}
+    </div>
+  );
+}

--- a/app/(sign)/sign/[id]/components/SignedDocumentDownloadButton.tsx
+++ b/app/(sign)/sign/[id]/components/SignedDocumentDownloadButton.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Download, Loader2 } from "lucide-react";
+import { useLanguage } from "@/contexts/language-context";
+import { getSignedDocumentUrlForSigner } from "@/app/actions/document-actions";
+
+interface SignedDocumentDownloadButtonProps {
+  shortUrl: string;
+  documentId: string;
+  password?: string | null;
+}
+
+export default function SignedDocumentDownloadButton({
+  shortUrl,
+  documentId,
+  password,
+}: SignedDocumentDownloadButtonProps) {
+  const { t } = useLanguage();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDownload = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await getSignedDocumentUrlForSigner(
+        shortUrl,
+        documentId,
+        password
+      );
+
+      if (result.error || !result.downloadUrl) {
+        setError(t("sign.completed.downloadError"));
+        return;
+      }
+
+      // The signed URL already carries a download content-disposition.
+      const link = document.createElement("a");
+      link.href = result.downloadUrl;
+      link.rel = "noopener noreferrer";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    } catch {
+      setError(t("sign.completed.downloadError"));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={handleDownload} disabled={isLoading} className="w-full">
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            {t("sign.completed.downloadLoading")}
+          </>
+        ) : (
+          <>
+            <Download className="mr-2 h-4 w-4" />
+            {t("sign.completed.download")}
+          </>
+        )}
+      </Button>
+      {error && (
+        <p className="text-sm text-red-500 text-center">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -1283,6 +1283,107 @@ export async function getSignedDocumentUrls(documentId: string): Promise<{
 }
 
 /**
+ * Get a short-lived signed download URL of a completed document for the
+ * anonymous signer (no auth). Access is scoped to the publication referenced
+ * by `shortUrl`, and the document must belong to that publication and be
+ * completed. Password-protected publications require server-side re-verification.
+ */
+export async function getSignedDocumentUrlForSigner(
+  shortUrl: string,
+  documentId: string,
+  password?: string | null
+): Promise<{ downloadUrl: string | null; error?: string }> {
+  try {
+    // Service role: anonymous signers have no auth session
+    const supabaseService = createServiceSupabase();
+
+    // 1. Resolve publication by short URL
+    const { data: publication, error: pubError } = await supabaseService
+      .from("publications")
+      .select("id, password")
+      .eq("short_url", shortUrl)
+      .single();
+
+    if (pubError || !publication) {
+      return { downloadUrl: null, error: "Publication not found" };
+    }
+
+    // 2. Password gate (server-side re-verification, not just client state)
+    if (publication.password) {
+      if (!password) {
+        return { downloadUrl: null, error: "Password required" };
+      }
+      const isValid = await bcrypt.compare(password, publication.password);
+      if (!isValid) {
+        return { downloadUrl: null, error: "Invalid password" };
+      }
+    }
+
+    // 3. Document must belong to this publication and be completed (IDOR defense)
+    const { data: document, error: docError } = await supabaseService
+      .from("documents")
+      .select("id, filename, status, signed_pdf_url, signed_file_url, publication_id")
+      .eq("id", documentId)
+      .eq("publication_id", publication.id)
+      .single();
+
+    if (docError || !document) {
+      return { downloadUrl: null, error: "Document not found" };
+    }
+
+    if (document.status !== "completed") {
+      return { downloadUrl: null, error: "Document not completed" };
+    }
+
+    const extractPath = (value: string) => {
+      if (!value) return null;
+      if (value.startsWith("http://") || value.startsWith("https://")) {
+        try {
+          const url = new URL(value);
+          const parts = url.pathname.split("/");
+          const index = parts.indexOf("signed-documents");
+          if (index === -1) return null;
+          return parts.slice(index + 1).join("/");
+        } catch {
+          return null;
+        }
+      }
+      return value.startsWith("signed-documents/")
+        ? value.substring("signed-documents/".length)
+        : value;
+    };
+
+    // Prefer the PDF artifact; fall back to legacy image artifact
+    const isPdf = !!document.signed_pdf_url;
+    const source = document.signed_pdf_url || document.signed_file_url;
+    const path = source ? extractPath(source) : null;
+
+    if (!path) {
+      return { downloadUrl: null, error: "Signed document not available" };
+    }
+
+    const originalName =
+      document.filename.replace(/\.[^/.]+$/, "") || document.filename;
+    const downloadName = `서명완료_${originalName}.${isPdf ? "pdf" : "png"}`;
+
+    // 4. Issue short-lived (5 min) signed URL with download disposition
+    const { data, error: urlError } = await supabaseService.storage
+      .from("signed-documents")
+      .createSignedUrl(path, 300, { download: downloadName });
+
+    if (urlError || !data) {
+      console.error("Error creating signer download URL:", urlError);
+      return { downloadUrl: null, error: "Failed to generate download URL" };
+    }
+
+    return { downloadUrl: data.signedUrl };
+  } catch (error) {
+    console.error("Get signer download URL error:", error);
+    return { downloadUrl: null, error: "An unexpected error occurred" };
+  }
+}
+
+/**
  * Delete a document (only draft status documents can be deleted)
  */
 export async function deleteDocument(documentId: string): Promise<{

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -1384,6 +1384,152 @@ export async function getSignedDocumentUrlForSigner(
 }
 
 /**
+ * Resolve a stored signed-document URL/path into a storage object path.
+ */
+function extractSignedDocumentPath(value: string | null): string | null {
+  if (!value) return null;
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    try {
+      const url = new URL(value);
+      const parts = url.pathname.split("/");
+      const index = parts.indexOf("signed-documents");
+      if (index === -1) return null;
+      return parts.slice(index + 1).join("/");
+    } catch {
+      return null;
+    }
+  }
+  return value.startsWith("signed-documents/")
+    ? value.substring("signed-documents/".length)
+    : value;
+}
+
+/**
+ * Get a single download for the anonymous signer covering ALL completed
+ * documents of a publication. One completed document → a direct signed URL;
+ * multiple → a zip archive (base64) bundling each signed document.
+ * Access is scoped to the publication and gated by its password.
+ */
+export async function getSignedDocumentBundleForSigner(
+  shortUrl: string,
+  password?: string | null
+): Promise<{
+  downloadUrl?: string | null;
+  zipBase64?: string;
+  filename?: string;
+  error?: string;
+}> {
+  try {
+    const supabaseService = createServiceSupabase();
+
+    // 1. Resolve publication by short URL
+    const { data: publication, error: pubError } = await supabaseService
+      .from("publications")
+      .select("id, name, password")
+      .eq("short_url", shortUrl)
+      .single();
+
+    if (pubError || !publication) {
+      return { error: "Publication not found" };
+    }
+
+    // 2. Password gate (server-side re-verification)
+    if (publication.password) {
+      if (!password) {
+        return { error: "Password required" };
+      }
+      const isValid = await bcrypt.compare(password, publication.password);
+      if (!isValid) {
+        return { error: "Invalid password" };
+      }
+    }
+
+    // 3. All completed documents belonging to this publication
+    const { data: documents, error: docError } = await supabaseService
+      .from("documents")
+      .select("id, filename, alias, status, signed_pdf_url, signed_file_url")
+      .eq("publication_id", publication.id)
+      .eq("status", "completed");
+
+    if (docError) {
+      return { error: "Failed to load documents" };
+    }
+
+    const completed = (documents ?? [])
+      .map((doc) => {
+        const isPdf = !!doc.signed_pdf_url;
+        const path = extractSignedDocumentPath(
+          doc.signed_pdf_url || doc.signed_file_url
+        );
+        const baseName =
+          (doc.alias || doc.filename || "document").replace(/\.[^/.]+$/, "") ||
+          "document";
+        return path ? { path, isPdf, baseName } : null;
+      })
+      .filter((d): d is { path: string; isPdf: boolean; baseName: string } => !!d);
+
+    if (completed.length === 0) {
+      return { error: "Signed document not available" };
+    }
+
+    const storage = supabaseService.storage.from("signed-documents");
+
+    // 4a. Single document → direct signed URL (no zip)
+    if (completed.length === 1) {
+      const { path, isPdf, baseName } = completed[0];
+      const downloadName = `서명완료_${baseName}.${isPdf ? "pdf" : "png"}`;
+      const { data, error: urlError } = await storage.createSignedUrl(
+        path,
+        300,
+        { download: downloadName }
+      );
+      if (urlError || !data) {
+        console.error("Error creating signer download URL:", urlError);
+        return { error: "Failed to generate download URL" };
+      }
+      return { downloadUrl: data.signedUrl };
+    }
+
+    // 4b. Multiple documents → zip archive
+    const JSZip = (await import("jszip")).default;
+    const zip = new JSZip();
+    const usedNames = new Set<string>();
+
+    for (const { path, isPdf, baseName } of completed) {
+      const { data: blob, error: dlError } = await storage.download(path);
+      if (dlError || !blob) {
+        console.error(`Failed to download ${path} for zip:`, dlError);
+        continue;
+      }
+      const bytes = new Uint8Array(await blob.arrayBuffer());
+      let name = `서명완료_${baseName}.${isPdf ? "pdf" : "png"}`;
+      let counter = 2;
+      while (usedNames.has(name)) {
+        name = `서명완료_${baseName} (${counter}).${isPdf ? "pdf" : "png"}`;
+        counter += 1;
+      }
+      usedNames.add(name);
+      zip.file(name, bytes);
+    }
+
+    if (usedNames.size === 0) {
+      return { error: "Signed document not available" };
+    }
+
+    const zipBase64 = await zip.generateAsync({ type: "base64" });
+    const publicationName = (publication.name || "서명문서").replace(
+      /[\\/:*?"<>|]/g,
+      "_"
+    );
+
+    return { zipBase64, filename: `${publicationName}_서명완료.zip` };
+  } catch (error) {
+    console.error("Get signer document bundle error:", error);
+    return { error: "An unexpected error occurred" };
+  }
+}
+
+/**
  * Delete a document (only draft status documents can be deleted)
  */
 export async function deleteDocument(documentId: string): Promise<{

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -337,6 +337,9 @@ const translations: Record<Language, Record<string, string>> = {
     "sign.completed.message": "이 문서는 이미 서명이 완료되어 제출되었습니다. 서명 완료된 문서가 필요한 경우 문서 발행자에게 문의 부탁드립니다.",
     "sign.completed.noEdit": "더 이상 수정할 수 없습니다.",
     "sign.completed.status": "서명 완료됨",
+    "sign.completed.download": "서명 문서 다운로드",
+    "sign.completed.downloadLoading": "다운로드 준비 중...",
+    "sign.completed.downloadError": "다운로드 링크를 생성하지 못했습니다. 잠시 후 다시 시도해 주세요.",
     "sign.expired.title": "서명 기간 만료",
     "sign.expired.message": "죄송합니다. 이 문서의 서명 기간이 만료되었습니다.",
     "sign.expired.instruction":
@@ -1522,6 +1525,9 @@ const translations: Record<Language, Record<string, string>> = {
       "This document has already been signed and submitted. If you need the signed document, please contact the document issuer.",
     "sign.completed.noEdit": "No further changes can be made.",
     "sign.completed.status": "Signature Completed",
+    "sign.completed.download": "Download signed document",
+    "sign.completed.downloadLoading": "Preparing download...",
+    "sign.completed.downloadError": "Failed to generate the download link. Please try again later.",
     "sign.expired.title": "Signature Period Expired",
     "sign.expired.message":
       "Sorry, the signing period for this document has expired.",

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -334,7 +334,7 @@ const translations: Record<Language, Record<string, string>> = {
     "sign.password.incorrect": "비밀번호가 올바르지 않습니다.",
     "sign.password.error": "비밀번호 확인 중 오류가 발생했습니다.",
     "sign.completed.title": "이미 제출된 문서입니다",
-    "sign.completed.message": "이 문서는 이미 서명이 완료되어 제출되었습니다. 서명 완료된 문서가 필요한 경우 문서 발행자에게 문의 부탁드립니다.",
+    "sign.completed.message": "이 문서는 서명이 완료되어 제출되었습니다. 아래 버튼을 눌러 서명 완료 문서를 다운로드할 수 있습니다.",
     "sign.completed.noEdit": "더 이상 수정할 수 없습니다.",
     "sign.completed.status": "서명 완료됨",
     "sign.completed.download": "서명 문서 다운로드",
@@ -1522,7 +1522,7 @@ const translations: Record<Language, Record<string, string>> = {
     "sign.password.error": "An error occurred while verifying the password.",
     "sign.completed.title": "Document Already Submitted",
     "sign.completed.message":
-      "This document has already been signed and submitted. If you need the signed document, please contact the document issuer.",
+      "This document has been signed and submitted. You can download the signed document using the button below.",
     "sign.completed.noEdit": "No further changes can be made.",
     "sign.completed.status": "Signature Completed",
     "sign.completed.download": "Download signed document",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "embla-carousel-react": "8.5.1",
     "geist": "^1.3.1",
     "input-otp": "1.4.1",
+    "jszip": "^3.10.1",
     "lodash.throttle": "^4.1.1",
     "lucide-react": "^0.454.0",
     "next": "14.2.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      jszip:
+        specifier: ^3.10.1
+        version: 3.10.1
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
@@ -2203,6 +2206,9 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2501,6 +2507,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-in-the-middle@1.14.4:
     resolution: {integrity: sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==}
 
@@ -2547,6 +2556,9 @@ packages:
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2579,6 +2591,12 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2978,6 +2996,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
@@ -3088,6 +3109,9 @@ packages:
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -3149,6 +3173,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3170,6 +3197,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3233,6 +3263,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -5650,6 +5683,8 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  core-util-is@1.0.3: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -5903,6 +5938,8 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  immediate@3.0.6: {}
+
   import-in-the-middle@1.14.4:
     dependencies:
       acorn: 8.15.0
@@ -5943,6 +5980,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   jackspeak@3.4.3:
@@ -5968,6 +6007,17 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -6304,6 +6354,8 @@ snapshots:
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
 
+  process-nextick-args@2.0.1: {}
+
   progress@2.0.3: {}
 
   prop-types@15.8.1:
@@ -6416,6 +6468,16 @@ snapshots:
     dependencies:
       pify: 2.3.0
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
@@ -6522,6 +6584,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   scheduler@0.23.2:
@@ -6542,6 +6606,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  setimmediate@1.0.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -6598,6 +6664,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.2
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:


### PR DESCRIPTION
## 개요
서명 완료 페이지에서 서명자(익명 사용자)가 본인이 제출한 **서명완료 PDF를 직접 다운로드**할 수 있는 버튼을 추가합니다. 기존에는 소유자만 다운로드가 가능했습니다.

## 변경 사항
- **`getSignedDocumentUrlForSigner` 서버 액션 추가** (`app/actions/document-actions.ts`)
  - service role로 동작 (서명자는 인증 세션 없음)
  - `shortUrl` ↔ `documentId` 소속 검증 + `completed` 상태 검증 → **IDOR 방어**
  - 비밀번호 보호 publication은 서버측 `bcrypt` **재검증** (클라이언트 state 우회 차단)
  - 다운로드용 signed URL을 **5분 TTL**로 발급, 파일명 `서명완료_<원본명>.pdf`
- **`SignedDocumentDownloadButton` 공유 컴포넌트 추가** — 완료 직후 뷰 + 완료 문서 재진입 뷰 양쪽에 노출
- 검증한 비밀번호를 다운로드 액션까지 전파 (`SignDocumentList` → `SignPageContainer` → 버튼)
- ko/en i18n 키 3종 추가

DB 마이그레이션은 없습니다.

## 보안 고려
| 항목 | 대응 |
|------|------|
| IDOR (타 문서 무단 접근) | documentId의 publication 소속 + completed 검증 |
| 비밀번호 게이트 우회 | 서버측 bcrypt 재검증 |
| signed URL 토큰 유출 | TTL 5분으로 단축 |

남은 참고 리스크: 한 문서를 여러 당사자가 서명하는 경우 완성 PDF에 전원 서명이 포함됨(현재 정책상 허용).

## 검증
- `tsc --noEmit` 통과 (신규/수정 파일 타입 에러 없음, 기존 에러만 잔존)
- 런타임 수동 확인 권장: PDF/이미지 문서 × 비번 보호/무보호 조합으로 서명→완료→다운로드

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **새 기능**
  * 서명 완료 문서 다운로드: 완료된 문서마다 다운로드 버튼이 표시되며, 사용자는 서명된 문서를 직접 내려받을 수 있습니다.
  * 비밀번호 기반 다운로드 보호: 다운로드 화면에서 비밀번호 검증을 통과한 경우에만 다운로드가 활성화됩니다.
  * 다운로드 진행 상태 개선: 다운로드 준비 중/오류 시에 대한 안내 문구가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->