### PR TITLE
fix: iOS/Safari 17.4 미만에서 PDF 문서 로드 실패 해결

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -99,6 +99,16 @@ export default async function RootLayout({
   return (
     <html lang={language === "ko" ? "ko" : "en"} suppressHydrationWarning>
       <head>
+        {/*
+          Polyfill Promise.withResolvers for iOS/Safari < 17.4.
+          pdf.js v5 relies on it; without this, PDF documents fail to load
+          on older devices (e.g. iOS 17.3.x). Runs synchronously before any app code.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `if(typeof Promise.withResolvers!=="function"){Promise.withResolvers=function(){var resolve,reject;var promise=new Promise(function(res,rej){resolve=res;reject=rej;});return{promise:promise,resolve:resolve,reject:reject};};}`,
+          }}
+        />
         <meta name="naver-site-verification" content="24ae5cf6d9a265c90d7a677e7b820b8fbb00472b" />
         <OrganizationJsonLd />
         <WebSiteJsonLd baseUrl={BASE_URL} />

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -180,7 +180,9 @@ export default function DocumentUpload({ mode = "document" }: DocumentUploadProp
           import("pdfjs-dist").then(async (pdfjsLib) => {
             try {
               if (typeof window !== "undefined" && !pdfjsLib.GlobalWorkerOptions.workerSrc) {
-                pdfjsLib.GlobalWorkerOptions.workerSrc = `//cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjsLib.version}/build/pdf.worker.min.mjs`;
+                // Use the local, polyfilled worker (see scripts/build-pdf-worker.mjs)
+                // so PDFs work on iOS/Safari < 17.4 instead of the CDN worker.
+                pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
               }
               const arrayBuffer = await file.arrayBuffer();
               const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",
-    "postinstall": "cp node_modules/pdfjs-dist/build/pdf.worker.min.mjs public/pdf.worker.min.mjs"
+    "postinstall": "node scripts/build-pdf-worker.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/public/pdf.worker.min.mjs
+++ b/public/pdf.worker.min.mjs
@@ -1,3 +1,4 @@
+if(typeof Promise.withResolvers!=="function"){Promise.withResolvers=function(){var resolve,reject;var promise=new Promise(function(res,rej){resolve=res;reject=rej;});return{promise:promise,resolve:resolve,reject:reject};};}
 /**
  * @licstart The following is the entire license notice for the
  * JavaScript code in this page

--- a/scripts/build-pdf-worker.mjs
+++ b/scripts/build-pdf-worker.mjs
@@ -1,0 +1,20 @@
+// Copies the pdf.js worker into public/ and prepends a Promise.withResolvers
+// polyfill so PDFs render on iOS/Safari < 17.4 (e.g. iOS 17.3.x), where pdf.js v5
+// would otherwise throw "Promise.withResolvers is not a function" inside the worker.
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, "..");
+
+const src = resolve(root, "node_modules/pdfjs-dist/build/pdf.worker.min.mjs");
+const dest = resolve(root, "public/pdf.worker.min.mjs");
+
+const polyfill =
+  'if(typeof Promise.withResolvers!=="function"){Promise.withResolvers=function(){var resolve,reject;var promise=new Promise(function(res,rej){resolve=res;reject=rej;});return{promise:promise,resolve:resolve,reject:reject};};}\n';
+
+const workerSource = readFileSync(src, "utf8");
+writeFileSync(dest, polyfill + workerSource, "utf8");
+
+console.log("[build-pdf-worker] wrote polyfilled worker to public/pdf.worker.min.mjs");


### PR DESCRIPTION
## 문제

낮은 버전의 휴대폰(특히 **iOS 17.3.x**)에서 서명 페이지의 **PDF 발행 문서가 로드되지 않는** 이슈.
- 증상: "PDF 파일을 불러올 수 없습니다." 로 표시
- 이미지 문서는 정상, **PDF만** 실패

## 원인

- 프로젝트는 `pdfjs-dist@^5.5.207`(pdf.js v5)을 사용
- pdf.js v4.3+/v5는 내부적으로 **`Promise.withResolvers()`** 사용
- 이 API는 **Safari/iOS 17.4부터** 지원 → iOS 17.3.x에서는 `Promise.withResolvers is not a function`으로 PDF 로드 단계에서 throw

pdf.js는 **메인 스레드**와 **워커 스레드** 양쪽에서 이 API를 호출하므로 두 곳 모두 폴리필이 필요하다.

## 변경 사항

- **app/layout.tsx**: `<head>`에 동기 인라인 스크립트로 메인 스레드 `Promise.withResolvers` 폴리필 추가 (앱 코드보다 먼저 실행)
- **scripts/build-pdf-worker.mjs** (신규): 워커 파일에 동일 폴리필을 prepend 후 `public/`에 복사
- **package.json**: `postinstall`을 위 스크립트로 변경 (설치/배포 시 자동 적용)
- **components/document-upload.tsx**: 페이지 수 계산용 워커를 CDN 대신 로컬 폴리필 워커(`/pdf.worker.min.mjs`)로 통일
- **public/pdf.worker.min.mjs**: 폴리필이 prepend된 워커로 갱신

v5 다운그레이드 대비 회귀 위험이 낮은 폴리필 방식 선택.

## 검증

- `npm run build` 성공 (`/sign/[id]` 포함 전 라우트 정상 생성)
- 빌드 중 `RESEND_API_KEY` 관련 에러는 본 변경과 무관한 기존 환경 변수 이슈 (더미 키로 빌드 통과 확인)
- 실기기 검증 권장: iOS 17.3.x 기기에서 PDF 발행 문서 서명 페이지 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * iOS/Safari 17.4 이하 버전에서 PDF 파일 업로드 시 발생하던 호환성 문제를 해결했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->