### PR TITLE
fix: iOS 17.4 미만 PDF 로드 - 메인 스레드 폴리필 보장 및 진단 추가

### DIFF
--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import "@/lib/pdf-polyfill"; // Promise.withResolvers polyfill before any pdfjs-dist usage (iOS < 17.4)
 import type React from "react";
 
 import { useState, useRef, useEffect, useCallback } from "react";
@@ -182,7 +183,8 @@ export default function DocumentUpload({ mode = "document" }: DocumentUploadProp
               if (typeof window !== "undefined" && !pdfjsLib.GlobalWorkerOptions.workerSrc) {
                 // Use the local, polyfilled worker (see scripts/build-pdf-worker.mjs)
                 // so PDFs work on iOS/Safari < 17.4 instead of the CDN worker.
-                pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+                // Version query busts stale caches of the old non-polyfilled worker.
+                pdfjsLib.GlobalWorkerOptions.workerSrc = `/pdf.worker.min.mjs?v=${pdfjsLib.version}`;
               }
               const arrayBuffer = await file.arrayBuffer();
               const pdf = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;

--- a/components/pdf-page-renderer.tsx
+++ b/components/pdf-page-renderer.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import React, { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
+import "@/lib/pdf-polyfill"; // must come before pdfjs-dist (main-thread Promise.withResolvers)
 import * as pdfjsLib from "pdfjs-dist";
+import * as Sentry from "@sentry/nextjs";
 
-// Use local worker file from public/ to avoid CDN issues and iOS Safari compatibility problems
+// Use local worker file from public/ to avoid CDN issues and iOS Safari compatibility problems.
+// The version query string busts stale CDN/browser caches of the (previously non-polyfilled) worker.
 if (typeof window !== "undefined") {
-  pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.mjs";
+  pdfjsLib.GlobalWorkerOptions.workerSrc = `/pdf.worker.min.mjs?v=${pdfjsLib.version}`;
 }
 
 export interface PdfPageDimensions {
@@ -102,12 +105,22 @@ const PdfPageRenderer = forwardRef<PdfPageRendererRef, PdfPageRendererProps>(
 
           setPdfDoc(pdf);
           onTotalPagesChange?.(pdf.numPages);
-        } catch (err) {
+        } catch (err: any) {
           if (cancelled) return;
           console.error("PDF load error:", err);
+          // Report the real error so we can diagnose old-iOS/Safari failures (e.g. missing APIs).
+          Sentry.captureException(err, {
+            tags: { area: "pdf-load" },
+            extra: {
+              userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+              pdfjsVersion: pdfjsLib.version,
+              hasPromiseWithResolvers: typeof (Promise as any).withResolvers === "function",
+            },
+          });
           setIsLoading(false);
           setPdfDoc(null);
-          onLoadError?.("PDF 파일을 불러올 수 없습니다.");
+          const detail = err?.name || err?.message ? ` (${err?.name || ""}: ${err?.message || ""})` : "";
+          onLoadError?.(`PDF 파일을 불러올 수 없습니다.${detail}`);
         }
       };
 

--- a/lib/pdf-polyfill.ts
+++ b/lib/pdf-polyfill.ts
@@ -1,0 +1,18 @@
+// Promise.withResolvers polyfill for iOS/Safari < 17.4.
+// pdf.js v5 calls Promise.withResolvers() on the MAIN thread (e.g. getDocument /
+// PDFDocumentLoadingTask), so it must exist before pdf.js is imported. Importing this
+// module *before* "pdfjs-dist" guarantees the polyfill runs first, regardless of how
+// Next.js handles the inline <head> script.
+if (typeof Promise !== "undefined" && typeof (Promise as any).withResolvers !== "function") {
+  (Promise as any).withResolvers = function withResolvers<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  };
+}
+
+export {};


### PR DESCRIPTION
## 배경

PR #160(Promise.withResolvers 폴리필) 머지·배포 후에도 **iOS 17.3.1에서 PDF 발행 문서가 여전히 로드되지 않음**.

추가 조사로 확인한 사실:
- Supabase 로그: 전부 200, 17.3.1 기기는 원본 PDF를 **fetch조차 하지 않음** → 클라이언트 pdf.js가 네트워크 요청 전에 throw
- 배포된 `/pdf.worker.min.mjs`는 폴리필이 **정상 포함**됨(확인 완료)
- **프라이빗 모드에서도 재현** → 브라우저 워커 캐시 문제 아님

## 원인

pdf.js v5는 **메인 스레드**(`getDocument` / `PDFDocumentLoadingTask`)에서도 `Promise.withResolvers`를 호출한다. 기존 PR의 메인 스레드 폴리필은 `app/layout.tsx`의 `<head>` 인라인 스크립트였는데, **Next.js App Router에서 이 스크립트가 pdf.js 모듈보다 먼저 실행된다는 보장이 없어** 메인 스레드에서 로드 전에 throw 되었다. (워커는 정상이지만 메인 스레드가 먼저 죽음)

## 변경 사항

- **lib/pdf-polyfill.ts** (신규): `Promise.withResolvers` 폴리필 모듈
- **pdf-page-renderer.tsx / document-upload.tsx**: `pdfjs-dist` import **이전에** 폴리필을 import → ESM 평가 순서상 메인 스레드에서 항상 먼저 실행 보장
- **pdf-page-renderer.tsx**: 워커 URL에 `?v=<version>` 추가 → 옛 비폴리필 워커 캐시 무효화
- **pdf-page-renderer.tsx**: PDF 로드 실패 시 `Sentry.captureException` + 실제 에러 메시지를 화면 노출 (진단용, 원인 확정 후 제거 예정)

## 검증

- `npm run build` 성공 (`/sign/[id]` 포함 전 라우트 정상)
- 배포 후 iOS 17.3.1 실기기에서 PDF 발행 문서 서명 페이지 로드 확인 필요
- 만약 여전히 실패하면 화면/Sentry에 표시되는 실제 에러로 누락 API를 즉시 특정 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)