### PR TITLE
diag: PDF 렌더 실패 시 실제 에러 노출 + Sentry 캡처

### DIFF
--- a/components/pdf-page-renderer.tsx
+++ b/components/pdf-page-renderer.tsx
@@ -213,8 +213,16 @@ const PdfPageRenderer = forwardRef<PdfPageRendererRef, PdfPageRendererProps>(
         } catch (err: any) {
           if (cancelled || err?.name === "RenderingCancelledException") return;
           console.error("PDF render error:", err);
+          Sentry.captureException(err, {
+            tags: { area: "pdf-render" },
+            extra: {
+              userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "unknown",
+              pdfjsVersion: pdfjsLib.version,
+            },
+          });
           setIsLoading(false);
-          onLoadError?.("PDF 페이지를 렌더링할 수 없습니다.");
+          const detail = err?.name || err?.message ? ` (${err?.name || ""}: ${err?.message || ""})` : "";
+          onLoadError?.(`PDF 페이지를 렌더링할 수 없습니다.${detail}`);
         }
       };
 


### PR DESCRIPTION
## 배경

저버전 iOS PDF 폴리필(#160~#163) 적용 후, iOS 17.3.1에서 에러가 **"PDF를 불러올 수 없습니다"(로드 실패) → "PDF 페이지를 렌더링할 수 없습니다"(렌더 실패)** 로 전환됨.

- Supabase 로그상 17.3.1 기기가 **원본 PDF를 GET 200으로 실제 fetch** 확인 → **로드/파싱 단계는 완전히 통과**(모든 폴리필 동작)
- 이제 `page.render()` 캔버스 렌더 단계에서만 실패

## 문제

렌더 catch 블록이 고정 메시지만 노출해 실제 렌더 에러를 알 수 없음(로드 catch에는 이미 진단이 있었음).

## 변경 사항

- `components/pdf-page-renderer.tsx` 렌더 catch에 `Sentry.captureException`(tags: pdf-render) + 실제 에러(name/message)를 화면 메시지에 노출

진단용 변경이며, 원인(누락 API / 캔버스 한계 등) 확정 후 화면 노출 코드는 정리 예정.

## 검증

- `npm run build` 성공
- 배포 후 iOS 17.3.1에서 재시도 시 "PDF 페이지를 렌더링할 수 없습니다 (이름: 메시지)" 형태로 정확한 렌더 에러 확보 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * PDF 페이지 렌더링 실패 시 더 구체적인 오류 메시지를 표시하도록 개선되었습니다. 오류 추적 기능이 강화되어 문제 진단이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->