### PR TITLE
fix: 완료 문서 소프트 삭제 시 스토리지 파일 정리

### DIFF
--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -1558,7 +1558,7 @@ export async function deleteDocument(documentId: string): Promise<{
     // Get document to verify ownership and status
     const { data: document, error: docError } = await supabase
       .from("documents")
-      .select("id, user_id, status, file_url")
+      .select("id, user_id, status, file_url, signed_file_url, signed_pdf_url")
       .eq("id", documentId)
       .eq("user_id", user.id)
       .single();
@@ -1591,6 +1591,58 @@ export async function deleteDocument(documentId: string): Promise<{
       if (softDeleteError) {
         console.error("❌ SERVER: Soft delete error:", softDeleteError);
         return { error: "Failed to delete document" };
+      }
+
+      // Reclaim storage: the DB row remains as a soft-delete tombstone, but the
+      // underlying files are no longer needed. Best-effort — failures here must
+      // not fail the delete (the row is already marked deleted).
+      try {
+        const supabaseService = createServiceSupabase();
+
+        if (document.file_url) {
+          const { error: docStorageError } = await supabaseService.storage
+            .from("documents")
+            .remove([document.file_url]);
+          if (docStorageError) {
+            console.error("⚠️ SERVER: Soft delete - documents storage cleanup failed:", docStorageError);
+          }
+        }
+
+        // signed-documents: deterministic path + any paths embedded in the URLs.
+        const extractSignedPath = (value: string | null): string | null => {
+          if (!value) return null;
+          if (value.startsWith("http://") || value.startsWith("https://")) {
+            try {
+              const parts = new URL(value).pathname.split("/");
+              const idx = parts.indexOf("signed-documents");
+              return idx === -1 ? null : parts.slice(idx + 1).join("/");
+            } catch {
+              return null;
+            }
+          }
+          return value.startsWith("signed-documents/")
+            ? value.substring("signed-documents/".length)
+            : value;
+        };
+
+        const signedPaths = new Set<string>([
+          `${document.user_id}/signed_${documentId}.pdf`,
+          `${document.user_id}/signed_${documentId}.png`, // intermediate artifact, if any
+        ]);
+        const s1 = extractSignedPath(document.signed_file_url);
+        const s2 = extractSignedPath(document.signed_pdf_url);
+        if (s1) signedPaths.add(s1);
+        if (s2) signedPaths.add(s2);
+
+        const { error: signedStorageError } = await supabaseService.storage
+          .from("signed-documents")
+          .remove([...signedPaths]);
+        if (signedStorageError) {
+          console.error("⚠️ SERVER: Soft delete - signed-documents storage cleanup failed:", signedStorageError);
+        }
+      } catch (storageError) {
+        console.error("⚠️ SERVER: Soft delete - storage cleanup error:", storageError);
+        // Non-critical: document is already soft-deleted.
       }
 
       // Revalidate pages

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -1641,46 +1641,31 @@ export async function deleteDocument(documentId: string): Promise<{
       // underlying files are no longer needed. Best-effort — failures here must
       // not fail the delete (the row is already marked deleted).
       try {
-        const supabaseService = createServiceSupabase();
+        const storage = getStorage();
 
         if (document.file_url) {
-          const { error: docStorageError } = await supabaseService.storage
-            .from("documents")
-            .remove([document.file_url]);
+          const { error: docStorageError } = await storage.remove("documents", [
+            document.file_url,
+          ]);
           if (docStorageError) {
             console.error("⚠️ SERVER: Soft delete - documents storage cleanup failed:", docStorageError);
           }
         }
 
         // signed-documents: deterministic path + any paths embedded in the URLs.
-        const extractSignedPath = (value: string | null): string | null => {
-          if (!value) return null;
-          if (value.startsWith("http://") || value.startsWith("https://")) {
-            try {
-              const parts = new URL(value).pathname.split("/");
-              const idx = parts.indexOf("signed-documents");
-              return idx === -1 ? null : parts.slice(idx + 1).join("/");
-            } catch {
-              return null;
-            }
-          }
-          return value.startsWith("signed-documents/")
-            ? value.substring("signed-documents/".length)
-            : value;
-        };
-
         const signedPaths = new Set<string>([
           `${document.user_id}/signed_${documentId}.pdf`,
           `${document.user_id}/signed_${documentId}.png`, // intermediate artifact, if any
         ]);
-        const s1 = extractSignedPath(document.signed_file_url);
-        const s2 = extractSignedPath(document.signed_pdf_url);
+        const s1 = extractSignedDocumentPath(document.signed_file_url);
+        const s2 = extractSignedDocumentPath(document.signed_pdf_url);
         if (s1) signedPaths.add(s1);
         if (s2) signedPaths.add(s2);
 
-        const { error: signedStorageError } = await supabaseService.storage
-          .from("signed-documents")
-          .remove([...signedPaths]);
+        const { error: signedStorageError } = await storage.remove(
+          "signed-documents",
+          [...signedPaths]
+        );
         if (signedStorageError) {
           console.error("⚠️ SERVER: Soft delete - signed-documents storage cleanup failed:", signedStorageError);
         }

--- a/scripts/cleanup-soft-deleted-storage.mjs
+++ b/scripts/cleanup-soft-deleted-storage.mjs
@@ -1,0 +1,133 @@
+// 소프트 삭제된(is_deleted=true) 문서의 스토리지 파일을 정리하는 일회성 스크립트.
+//
+// 사용법:
+//   node scripts/cleanup-soft-deleted-storage.mjs            # dry-run (미리보기만)
+//   node scripts/cleanup-soft-deleted-storage.mjs --execute  # 실제 삭제
+//
+// - documents 버킷: file_url 경로
+// - signed-documents 버킷: signed_{id}.pdf + 중간 산출물 signed_{id}.png (URL에서 추출한 경로 포함)
+// DB row(소프트 삭제 tombstone)는 건드리지 않고 스토리지 파일만 제거한다.
+
+import { readFileSync } from "node:fs";
+import { createClient } from "@supabase/supabase-js";
+
+const EXECUTE = process.argv.includes("--execute");
+
+// .env.local 수동 파싱 (dotenv 의존성 없이)
+function loadEnv() {
+  const env = {};
+  try {
+    const raw = readFileSync(new URL("../.env.local", import.meta.url), "utf8");
+    for (const line of raw.split("\n")) {
+      const m = line.match(/^\s*([A-Z0-9_]+)\s*=\s*(.*)\s*$/);
+      if (m) env[m[1]] = m[2].replace(/^["']|["']$/g, "");
+    }
+  } catch (e) {
+    console.error("⚠️  .env.local 읽기 실패:", e.message);
+  }
+  return env;
+}
+
+const env = loadEnv();
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY || env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !key) {
+  console.error("❌ NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY 가 필요합니다.");
+  process.exit(1);
+}
+
+const supabase = createClient(url, key, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+function extractSignedPath(value) {
+  if (!value) return null;
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    try {
+      const parts = new URL(value).pathname.split("/");
+      const idx = parts.indexOf("signed-documents");
+      return idx === -1 ? null : parts.slice(idx + 1).join("/");
+    } catch {
+      return null;
+    }
+  }
+  return value.startsWith("signed-documents/")
+    ? value.substring("signed-documents/".length)
+    : value;
+}
+
+async function chunkedRemove(bucket, paths) {
+  const unique = [...new Set(paths.filter(Boolean))];
+  let removed = 0;
+  for (let i = 0; i < unique.length; i += 100) {
+    const batch = unique.slice(i, i + 100);
+    if (EXECUTE) {
+      const { data, error } = await supabase.storage.from(bucket).remove(batch);
+      if (error) {
+        console.error(`  ❌ ${bucket} 배치 삭제 실패:`, error.message);
+      } else {
+        removed += data?.length ?? 0;
+      }
+    }
+  }
+  return { total: unique.length, removed };
+}
+
+async function main() {
+  console.log(`\n=== 소프트 삭제 문서 스토리지 정리 (${EXECUTE ? "EXECUTE 🔴" : "DRY-RUN 🟡"}) ===\n`);
+
+  // 페이지네이션으로 전체 조회 (기본 1000 limit 대비 안전)
+  const docs = [];
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase
+      .from("documents")
+      .select("id, user_id, file_url, signed_file_url, signed_pdf_url")
+      .eq("is_deleted", true)
+      .range(from, from + pageSize - 1);
+    if (error) throw error;
+    docs.push(...data);
+    if (data.length < pageSize) break;
+  }
+
+  console.log(`대상 소프트 삭제 문서: ${docs.length}개`);
+
+  const docPaths = [];
+  const signedPaths = [];
+  for (const d of docs) {
+    if (d.file_url) docPaths.push(d.file_url);
+    // 결정적 경로
+    signedPaths.push(`${d.user_id}/signed_${d.id}.pdf`);
+    signedPaths.push(`${d.user_id}/signed_${d.id}.png`); // 중간 산출물(있을 수 있음)
+    // URL에서 추출한 경로도 포함 (belt & suspenders)
+    const s1 = extractSignedPath(d.signed_file_url);
+    const s2 = extractSignedPath(d.signed_pdf_url);
+    if (s1) signedPaths.push(s1);
+    if (s2) signedPaths.push(s2);
+  }
+
+  const uniqueDoc = [...new Set(docPaths.filter(Boolean))];
+  const uniqueSigned = [...new Set(signedPaths.filter(Boolean))];
+  console.log(`  documents 버킷 대상 경로: ${uniqueDoc.length}개`);
+  console.log(`  signed-documents 버킷 대상 경로(후보, png 포함): ${uniqueSigned.length}개`);
+
+  if (!EXECUTE) {
+    console.log("\n[미리보기] 실제 삭제하려면 --execute 플래그를 붙여 다시 실행하세요.");
+    console.log("샘플 documents 경로:", uniqueDoc.slice(0, 3));
+    console.log("샘플 signed 경로   :", uniqueSigned.slice(0, 3));
+    return;
+  }
+
+  const docResult = await chunkedRemove("documents", uniqueDoc);
+  const signedResult = await chunkedRemove("signed-documents", uniqueSigned);
+
+  console.log(`\n✅ 완료`);
+  console.log(`  documents: ${docResult.removed}/${docResult.total} 삭제`);
+  console.log(`  signed-documents: ${signedResult.removed}/${signedResult.total} 삭제 (없는 png 경로는 무시됨)`);
+}
+
+main().catch((e) => {
+  console.error("❌ 스크립트 오류:", e);
+  process.exit(1);
+});

--- a/scripts/cleanup-soft-deleted-storage.mjs
+++ b/scripts/cleanup-soft-deleted-storage.mjs
@@ -85,6 +85,7 @@ async function main() {
       .from("documents")
       .select("id, user_id, file_url, signed_file_url, signed_pdf_url")
       .eq("is_deleted", true)
+      .order("id", { ascending: true })
       .range(from, from + pageSize - 1);
     if (error) throw error;
     docs.push(...data);

--- a/scripts/migrate-storage-to-r2.mjs
+++ b/scripts/migrate-storage-to-r2.mjs
@@ -67,6 +67,7 @@ async function collectKeys() {
     const { data, error } = await supabase
       .from("documents")
       .select("file_url, signed_file_url, signed_pdf_url")
+      .order("id", { ascending: true })
       .range(from, from + page - 1);
     if (error) throw error;
     if (!data.length) break;
@@ -85,6 +86,7 @@ async function collectKeys() {
     const { data, error } = await supabase
       .from("document_templates")
       .select("file_url")
+      .order("id", { ascending: true })
       .range(from, from + page - 1);
     if (error) throw error;
     if (!data.length) break;


### PR DESCRIPTION
## 배경
서명 발행 후 제출이 실패하는 문제를 조사한 결과, **Supabase 무료 플랜 스토리지(1GB)가 964MB(96%)로 한도에 도달**해 신규 서명본 업로드가 막히는 상황이었습니다.

근본 원인은 `completed` 문서의 **소프트 삭제(`is_deleted=true`)가 DB tombstone만 남기고 실제 스토리지 파일을 삭제하지 않는 것**이었습니다. 사용자가 UI에서 삭제한 문서의 원본/서명본 파일이 계속 누적되어 스토리지를 잠식했습니다.

## 변경 내용
- `deleteDocument`의 `completed` 분기에서 소프트 삭제 시 서비스 롤 클라이언트로 스토리지 파일도 제거
  - `documents` 버킷: 원본 파일(`file_url`)
  - `signed-documents` 버킷: `signed_{id}.pdf` + 중간 산출물 `signed_{id}.png` (URL에서 추출한 경로 포함)
  - **best-effort**: 스토리지 삭제 실패해도 소프트 삭제 자체는 성공 유지 (row는 이미 tombstone 처리됨)
- 기존 누적분 정리용 일회성 스크립트 추가 (`scripts/cleanup-soft-deleted-storage.mjs`)
  - dry-run 기본, `--execute` 플래그로 실제 삭제

## 크로스체크 (안전성 검증)
- 소프트 삭제 문서 186개의 파일이 **살아있는 문서와 공유 0건** 확인 후 정리
- DB row(tombstone)는 그대로 유지 → 월별 사용량 집계/감사 추적 일관성 보존

## 운영 조치 (이미 수행)
스크립트를 `--execute`로 실행해 기존 누적분 정리 완료:

| 버킷 | Before | After |
|------|--------|-------|
| documents | 426 MB | 332 MB |
| signed-documents | 538 MB | 416 MB |
| **합계** | **964 MB (96%)** | **748 MB (75%)** |

→ **약 216MB 회수, 제출 실패 즉시 해소.**

## 참고
현재 75%라 사용량 증가 시 다시 찰 수 있어, 중장기적으로 Pro 플랜(스토리지 100GB) 업그레이드 검토를 권장합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 완료된 문서를 삭제할 때 관련 파일도 함께 정리되도록 개선되어, 삭제 후 남는 불필요한 파일이 줄어듭니다.
  * 삭제 과정에서 일부 파일 정리가 실패해도 전체 삭제는 계속 진행되도록 안정성이 향상되었습니다.

* **Chores**
  * 삭제된 문서의 남은 저장소 파일을 한 번에 정리할 수 있는 점검 도구가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->