### PR TITLE
refactor(storage): R2 무중단 이관 1차 — dual-write + read-fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ PADDLE_CREDIT_PRICE_ID=pri_01xxxxxxxxxxxxxxxxxxxxx
 # Your site's public URL (used for OAuth redirects, emails, etc.)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# Storage provider: "supabase" (default) or "r2"
+# Storage provider: "supabase" (default) | "dual" (write both, read R2→Supabase) | "r2"
 STORAGE_PROVIDER=supabase
 # Cloudflare R2 (S3-compatible)
 R2_ACCOUNT_ID=

--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,13 @@ PADDLE_CREDIT_PRICE_ID=pri_01xxxxxxxxxxxxxxxxxxxxx
 # -------------------------------------------
 # Your site's public URL (used for OAuth redirects, emails, etc.)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+# Storage provider: "supabase" (default) or "r2"
+STORAGE_PROVIDER=supabase
+# Cloudflare R2 (S3-compatible)
+R2_ACCOUNT_ID=
+R2_ENDPOINT=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_DOCUMENTS=documents
+R2_BUCKET_SIGNED=signed-documents

--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -295,8 +295,7 @@ export default function DocumentDetailComponent({
         const { url, error } = await getOwnedDocumentFileUrl(document.id);
         if (!active) return;
         if (error || !url) {
-          console.error('Failed to load document:', error);
-          return;
+          throw new Error(error || "Missing document file URL");
         }
 
         // Fetch via presigned URL and keep the blob-URL contract for renderers.
@@ -307,7 +306,9 @@ export default function DocumentDetailComponent({
         objectUrl = URL.createObjectURL(blob);
         setDocumentUrl(objectUrl);
       } catch (err) {
-        if (active) console.error('Failed to load document:', err);
+        if (!active) return;
+        console.error('Failed to load document:', err);
+        setError(t("documentDetail.errorLoadFile", "문서를 불러오지 못했습니다."));
       }
     };
 

--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   updateSignatureAreas,
   getSignedDocumentUrls,
   deleteDocument,
+  getOwnedDocumentFileUrl,
 } from "@/app/actions/document-actions";
 import AreaSelector from "@/components/area-selector";
 import DeleteDocumentModal from "@/components/delete-document-modal";
@@ -42,7 +43,6 @@ import { Edit, Download, Trash2, ZoomIn, ZoomOut, RotateCcw, Share2, Type, Chevr
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useRef, useState, useEffect } from "react";
-import { createClientSupabase } from "@/lib/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 
 interface DocumentDetailComponentProps {
@@ -288,21 +288,17 @@ export default function DocumentDetailComponent({
   useEffect(() => {
     const loadDocumentUrl = async () => {
       if (document.file_url) {
-        const supabase = createClientSupabase();
-        const { data, error } = await supabase.storage
-          .from('documents')
-          .download(document.file_url);
+        const { url, error } = await getOwnedDocumentFileUrl(document.id);
 
-        if (error) {
+        if (error || !url) {
           console.error('Failed to load document:', error);
           return;
         }
 
-        if (data) {
-          // Create blob URL from downloaded data
-          const url = URL.createObjectURL(data);
-          setDocumentUrl(url);
-        }
+        // Fetch via presigned URL and keep the blob-URL contract for renderers.
+        const res = await fetch(url);
+        const blob = await res.blob();
+        setDocumentUrl(URL.createObjectURL(blob));
       }
     };
 

--- a/app/(document)/document/[id]/components/DocumentDetailPage.tsx
+++ b/app/(document)/document/[id]/components/DocumentDetailPage.tsx
@@ -284,12 +284,16 @@ export default function DocumentDetailComponent({
     setIsMounted(true);
   }, []);
 
-  // Load original document URL from private storage using authenticated download
+  // Load original document URL via server-issued presigned URL
   useEffect(() => {
-    const loadDocumentUrl = async () => {
-      if (document.file_url) {
-        const { url, error } = await getOwnedDocumentFileUrl(document.id);
+    let objectUrl: string | null = null;
+    let active = true;
 
+    const loadDocumentUrl = async () => {
+      if (!document.file_url) return;
+      try {
+        const { url, error } = await getOwnedDocumentFileUrl(document.id);
+        if (!active) return;
         if (error || !url) {
           console.error('Failed to load document:', error);
           return;
@@ -297,20 +301,24 @@ export default function DocumentDetailComponent({
 
         // Fetch via presigned URL and keep the blob-URL contract for renderers.
         const res = await fetch(url);
+        if (!res.ok) throw new Error(`Failed to fetch document: ${res.status}`);
         const blob = await res.blob();
-        setDocumentUrl(URL.createObjectURL(blob));
+        if (!active) return;
+        objectUrl = URL.createObjectURL(blob);
+        setDocumentUrl(objectUrl);
+      } catch (err) {
+        if (active) console.error('Failed to load document:', err);
       }
     };
 
     loadDocumentUrl();
 
-    // Cleanup: revoke blob URL when component unmounts
+    // Cleanup: revoke the exact blob URL created in this effect run.
     return () => {
-      if (documentUrl) {
-        URL.revokeObjectURL(documentUrl);
-      }
+      active = false;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [document.file_url]);
+  }, [document.id, document.file_url]);
 
   // 완료된 문서의 경우 서명된 문서 리소스 가져오기
   useEffect(() => {

--- a/app/(document)/templates/[id]/components/TemplateDetailPageContent.tsx
+++ b/app/(document)/templates/[id]/components/TemplateDetailPageContent.tsx
@@ -26,7 +26,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useLanguage } from "@/contexts/language-context";
-import { createClientSupabase } from "@/lib/supabase/client";
 import type {
   SignatureArea,
   TemplateWithAreas,
@@ -35,6 +34,7 @@ import type { RelativeSignatureArea } from "@/lib/utils";
 import {
   deleteTemplate,
   updateTemplate,
+  getOwnedTemplateFileUrl,
 } from "@/app/actions/template-actions";
 
 interface TemplateDetailPageContentProps {
@@ -99,22 +99,23 @@ export function TemplateDetailPageContent({
     let active = true;
 
     const loadTemplateFile = async () => {
-      const supabase = createClientSupabase();
-      const { data, error: downloadError } = await supabase.storage
-        .from("documents")
-        .download(template.file_url);
+      const { url, error: urlError } = await getOwnedTemplateFileUrl(template.id);
 
       if (!active) return;
 
-      if (downloadError || !data) {
-        console.error("Failed to load template file:", downloadError);
+      if (urlError || !url) {
+        console.error("Failed to load template file:", urlError);
         setError(
           t("templates.detail.loadFileError", "템플릿 파일을 불러오지 못했습니다.")
         );
         return;
       }
 
-      objectUrl = URL.createObjectURL(data);
+      const res = await fetch(url);
+      const blob = await res.blob();
+      if (!active) return;
+
+      objectUrl = URL.createObjectURL(blob);
       setDocumentUrl(objectUrl);
     };
 

--- a/app/(document)/templates/[id]/components/TemplateDetailPageContent.tsx
+++ b/app/(document)/templates/[id]/components/TemplateDetailPageContent.tsx
@@ -99,24 +99,27 @@ export function TemplateDetailPageContent({
     let active = true;
 
     const loadTemplateFile = async () => {
-      const { url, error: urlError } = await getOwnedTemplateFileUrl(template.id);
+      try {
+        const { url, error: urlError } = await getOwnedTemplateFileUrl(template.id);
+        if (!active) return;
+        if (urlError || !url) {
+          throw new Error(urlError || "Missing template file URL");
+        }
 
-      if (!active) return;
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`Failed to fetch template file: ${res.status}`);
+        const blob = await res.blob();
+        if (!active) return;
 
-      if (urlError || !url) {
-        console.error("Failed to load template file:", urlError);
+        objectUrl = URL.createObjectURL(blob);
+        setDocumentUrl(objectUrl);
+      } catch (err) {
+        if (!active) return;
+        console.error("Failed to load template file:", err);
         setError(
           t("templates.detail.loadFileError", "템플릿 파일을 불러오지 못했습니다.")
         );
-        return;
       }
-
-      const res = await fetch(url);
-      const blob = await res.blob();
-      if (!active) return;
-
-      objectUrl = URL.createObjectURL(blob);
-      setDocumentUrl(objectUrl);
     };
 
     loadTemplateFile();

--- a/app/actions/account-actions.ts
+++ b/app/actions/account-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServerSupabase, createServiceSupabase } from "@/lib/supabase/server";
+import { getStorage } from "@/lib/storage";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 
@@ -162,9 +163,10 @@ export async function deleteAccount(
 
       // Delete from documents bucket
       if (filePaths.length > 0) {
-        const { error: storageError } = await serviceSupabase.storage
-          .from("documents")
-          .remove(filePaths);
+        const { error: storageError } = await getStorage().remove(
+          "documents",
+          filePaths
+        );
 
         if (storageError) {
           console.error("[Account Deletion] Error deleting from documents storage:", storageError);
@@ -176,9 +178,10 @@ export async function deleteAccount(
 
       // Delete from signed-documents bucket
       if (signedFilePaths.length > 0) {
-        const { error: signedStorageError } = await serviceSupabase.storage
-          .from("signed-documents")
-          .remove(signedFilePaths);
+        const { error: signedStorageError } = await getStorage().remove(
+          "signed-documents",
+          signedFilePaths
+        );
 
         if (signedStorageError) {
           console.error("[Account Deletion] Error deleting from signed-documents storage:", signedStorageError);

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -939,6 +939,51 @@ export async function getDocumentFileSignedUrl(
 }
 
 /**
+ * Owner-scoped presigned URL for the original document file (for preview in the
+ * document detail page). Replaces client-side RLS storage.download so the
+ * browser never talks to storage directly.
+ */
+export async function getOwnedDocumentFileUrl(documentId: string): Promise<{
+  url: string | null;
+  error?: string;
+}> {
+  try {
+    const supabase = await createServerSupabase();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { url: null, error: "User not authenticated" };
+    }
+
+    const { data: document, error: docError } = await supabase
+      .from("documents")
+      .select("id, file_url")
+      .eq("id", documentId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (docError || !document?.file_url) {
+      return { url: null, error: "Document not found" };
+    }
+
+    const { url, error } = await getStorage().createSignedDownloadUrl(
+      "documents",
+      document.file_url,
+      { expiresIn: 3600 }
+    );
+    if (error || !url) {
+      return { url: null, error: error ?? "Failed to generate URL" };
+    }
+    return { url };
+  } catch (error) {
+    console.error("Get owned document file URL error:", error);
+    return { url: null, error: "An unexpected error occurred" };
+  }
+}
+
+/**
  * Get document by ID (for server components)
  */
 export async function getDocumentById(id: string): Promise<{

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -507,6 +507,14 @@ export async function generateSignedPdf(
 
     console.log(`[PDF] Document verified (${Date.now() - startTime}ms)`);
 
+    // Restrict to the owner's expected key (storage RLS is not a backstop when
+    // using service-role / R2). Prevents reading/deleting arbitrary keys.
+    const expectedImagePath = `${document.user_id}/signed_${documentId}.png`;
+    if (signedImagePath !== expectedImagePath) {
+      console.error("[PDF] Invalid signed image path:", signedImagePath);
+      return { error: "Invalid signed image path" };
+    }
+
     // Download the signed image from storage
     const storage = getStorage();
     const { data: imageBytes, contentType: imageType, error: downloadError } =
@@ -804,6 +812,7 @@ export async function generateSignedPdfFromPdf(documentId: string) {
 
     if (updateError) {
       console.error('[PDF-Sign] Update error:', updateError);
+      await storage.remove("signed-documents", [pdfPath]);
       return { error: 'Failed to update document' };
     }
 

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -16,6 +16,7 @@ import { randomUUID } from "crypto";
 import { canCreateDocument, incrementDocumentCreated, decrementDocumentCreated } from "./subscription-actions";
 import { sendDocumentCompletionEmail } from "./notification-actions";
 import { deductCredit, wasDocumentCreatedWithCredit, refundCredit } from "./credit-actions";
+import { getStorage } from "@/lib/storage";
 
 /**
  * Upload a file to Supabase Storage and create a document record
@@ -78,10 +79,13 @@ export async function uploadDocument(formData: FormData) {
     const uniqueFilename = `${randomUUID()}.${fileExtension}`;
     const filePath = `${user.id}/${uniqueFilename}`;
 
-    // Upload file to Supabase Storage with user_id folder structure
-    const { data: uploadData, error: uploadError } = await supabase.storage
-      .from("documents")
-      .upload(filePath, file);
+    // Upload file to storage with user_id folder structure
+    const { error: uploadError } = await getStorage().upload(
+      "documents",
+      filePath,
+      file,
+      { contentType: file.type }
+    );
 
     if (uploadError) {
       console.error("Upload error:", uploadError);
@@ -133,7 +137,7 @@ export async function uploadDocument(formData: FormData) {
 
         // Rollback: delete document and storage file
         await supabase.from("documents").delete().eq("id", document.id);
-        await supabase.storage.from("documents").remove([filePath]);
+        await getStorage().remove("documents", [filePath]);
 
         return { error: "크레딧 차감 실패" };
       }
@@ -408,6 +412,7 @@ export async function createSignedDocumentUploadUrl(
   uploadUrl?: string;
   filePath?: string;
   token?: string;
+  provider?: "supabase" | "r2";
   error?: string;
 }> {
   try {
@@ -439,34 +444,34 @@ export async function createSignedDocumentUploadUrl(
     const filePath = `${document.user_id}/${filename}`;
 
     // Check if file already exists and delete it (cleanup from failed previous attempts)
-    const { data: existingFiles } = await supabaseService.storage
-      .from('signed-documents')
-      .list(document.user_id, {
-        search: `signed_${documentId}`
-      });
+    const storage = getStorage();
+    const { keys: existingFiles } = await storage.list(
+      "signed-documents",
+      `${document.user_id}/signed_${documentId}`
+    );
 
-    if (existingFiles && existingFiles.length > 0) {
+    if (existingFiles.length > 0) {
       console.log(`[Upload] Cleaning up ${existingFiles.length} existing files for document ${documentId}`);
-      const filesToDelete = existingFiles.map(f => `${document.user_id}/${f.name}`);
-      await supabaseService.storage
-        .from('signed-documents')
-        .remove(filesToDelete);
+      await storage.remove("signed-documents", existingFiles);
     }
 
     // Create presigned upload URL (valid for 5 minutes)
-    const { data, error: urlError } = await supabaseService.storage
-      .from('signed-documents')
-      .createSignedUploadUrl(filePath);
+    const { result, error: urlError } = await storage.createSignedUploadUrl(
+      "signed-documents",
+      filePath,
+      { expiresIn: 300 }
+    );
 
-    if (urlError || !data) {
+    if (urlError || !result) {
       console.error('[Upload] Failed to create presigned URL:', urlError);
       return { error: 'Failed to create upload URL' };
     }
 
     return {
-      uploadUrl: data.signedUrl,
+      uploadUrl: result.url,
       filePath,
-      token: data.token,
+      token: result.token,
+      provider: result.provider,
     };
   } catch (error) {
     console.error('[Upload] Unexpected error:', error);
@@ -486,8 +491,6 @@ export async function generateSignedPdf(
   console.log(`[PDF] Starting PDF generation for ${documentId}`);
 
   try {
-    // Use service role to bypass RLS
-    const supabaseService = createServiceSupabase();
     const supabase = await createServerSupabase();
 
     // Get document to verify existence and get user_id
@@ -505,25 +508,18 @@ export async function generateSignedPdf(
     console.log(`[PDF] Document verified (${Date.now() - startTime}ms)`);
 
     // Download the signed image from storage
-    const { data: imageData, error: downloadError } = await supabaseService.storage
-      .from('signed-documents')
-      .download(signedImagePath);
+    const storage = getStorage();
+    const { data: imageBytes, contentType: imageType, error: downloadError } =
+      await storage.download("signed-documents", signedImagePath);
 
-    if (downloadError || !imageData) {
+    if (downloadError || !imageBytes) {
       console.error('[PDF] Failed to download signed image:', downloadError);
       return { error: 'Failed to download signed image' };
     }
 
-    const arrayBuffer = await imageData.arrayBuffer();
-    const imageBytes = new Uint8Array(arrayBuffer);
     console.log(
-      `[PDF] Image downloaded: ${imageData.type || 'unknown'}, ${Math.round(imageData.size / 1024)}KB (${Date.now() - startTime}ms)`
+      `[PDF] Image downloaded: ${imageType || 'unknown'}, ${Math.round(imageBytes.length / 1024)}KB (${Date.now() - startTime}ms)`
     );
-
-    // Get public URL for the uploaded file
-    const {
-      data: { publicUrl },
-    } = supabaseService.storage.from('signed-documents').getPublicUrl(signedImagePath);
 
     // Generate PDF from signed image with A4 size optimization
     const { PDFDocument } = await import('pdf-lib');
@@ -532,9 +528,9 @@ export async function generateSignedPdf(
     // Embed image based on MIME type
     let embeddedImage;
     try {
-      if (imageData.type === 'image/png' || !imageData.type) {
+      if (imageType === 'image/png' || !imageType) {
         embeddedImage = await pdfDoc.embedPng(imageBytes);
-      } else if (imageData.type === 'image/jpeg' || imageData.type === 'image/jpg') {
+      } else if (imageType === 'image/jpeg' || imageType === 'image/jpg') {
         embeddedImage = await pdfDoc.embedJpg(imageBytes);
       } else {
         // Fallback: try PNG first, then JPG
@@ -584,12 +580,12 @@ export async function generateSignedPdf(
     const pdfFilename = `signed_${documentId}.pdf`;
     const pdfPath = `${document.user_id}/${pdfFilename}`;
 
-    const { error: pdfUploadError } = await supabaseService.storage
-      .from('signed-documents')
-      .upload(pdfPath, pdfBlob, {
-        upsert: true,
-        contentType: 'application/pdf',
-      });
+    const { error: pdfUploadError } = await storage.upload(
+      "signed-documents",
+      pdfPath,
+      pdfBlob,
+      { upsert: true, contentType: 'application/pdf' }
+    );
 
     if (pdfUploadError) {
       console.error('[PDF] PDF upload failed:', pdfUploadError);
@@ -598,28 +594,20 @@ export async function generateSignedPdf(
 
     console.log(`[PDF] PDF uploaded successfully (${Date.now() - startTime}ms)`);
 
-    const {
-      data: { publicUrl: pdfPublicUrl },
-    } = supabaseService.storage.from('signed-documents').getPublicUrl(pdfPath);
-
-    // Update document with signed file URLs (use PDF URL for both)
+    // Store the storage key (private bucket; URLs are generated on read)
     const { error: updateError } = await supabase
       .from('documents')
-      .update({ signed_file_url: pdfPublicUrl, signed_pdf_url: pdfPublicUrl })
+      .update({ signed_file_url: pdfPath, signed_pdf_url: pdfPath })
       .eq('id', documentId);
 
     if (updateError) {
       console.error('[PDF] Update document error:', updateError);
-      await supabaseService.storage
-        .from('signed-documents')
-        .remove([pdfPath]);
+      await storage.remove("signed-documents", [pdfPath]);
       return { error: 'Failed to update document with signed file URL' };
     }
 
     // Delete the intermediate PNG file since PDF is now the primary format
-    const { error: pngDeleteError } = await supabaseService.storage
-      .from('signed-documents')
-      .remove([signedImagePath]);
+    const { error: pngDeleteError } = await storage.remove("signed-documents", [signedImagePath]);
 
     if (pngDeleteError) {
       // Non-critical: log but don't fail the operation
@@ -633,7 +621,7 @@ export async function generateSignedPdf(
     const totalTime = Date.now() - startTime;
     console.log(`[PDF] ✅ Complete! Total time: ${totalTime}ms`);
 
-    return { success: true, signedPdfUrl: pdfPublicUrl };
+    return { success: true, signedPdfUrl: pdfPath };
   } catch (error) {
     console.error('[PDF] ❌ Unexpected error:', error);
     return { error: 'An unexpected error occurred' };
@@ -669,11 +657,13 @@ export async function generateSignedPdfFromPdf(documentId: string) {
     }
 
     // Download original PDF
-    const { data: pdfData, error: downloadError } = await supabaseService.storage
-      .from('documents')
-      .download(document.file_url);
+    const storage = getStorage();
+    const { data: pdfBytes, error: downloadError } = await storage.download(
+      "documents",
+      document.file_url
+    );
 
-    if (downloadError || !pdfData) {
+    if (downloadError || !pdfBytes) {
       console.error('[PDF-Sign] Failed to download PDF:', downloadError);
       return { error: 'Failed to download original PDF' };
     }
@@ -694,8 +684,7 @@ export async function generateSignedPdfFromPdf(documentId: string) {
 
     // Load original PDF with pdf-lib
     const { PDFDocument } = await import('pdf-lib');
-    const pdfArrayBuffer = await pdfData.arrayBuffer();
-    const pdfDoc = await PDFDocument.load(pdfArrayBuffer);
+    const pdfDoc = await PDFDocument.load(pdfBytes);
     const pages = pdfDoc.getPages();
 
     console.log(`[PDF-Sign] PDF loaded with ${pages.length} pages (${Date.now() - startTime}ms)`);
@@ -795,26 +784,22 @@ export async function generateSignedPdfFromPdf(documentId: string) {
     const pdfPath = `${document.user_id}/${pdfFilename}`;
 
     // Upload signed PDF
-    const { error: uploadError } = await supabaseService.storage
-      .from('signed-documents')
-      .upload(pdfPath, pdfBlob, {
-        upsert: true,
-        contentType: 'application/pdf',
-      });
+    const { error: uploadError } = await storage.upload(
+      "signed-documents",
+      pdfPath,
+      pdfBlob,
+      { upsert: true, contentType: 'application/pdf' }
+    );
 
     if (uploadError) {
       console.error('[PDF-Sign] Upload failed:', uploadError);
       return { error: 'Failed to upload signed PDF' };
     }
 
-    const { data: { publicUrl: pdfPublicUrl } } = supabaseService.storage
-      .from('signed-documents')
-      .getPublicUrl(pdfPath);
-
-    // Update document with signed file URLs
+    // Store the storage key (private bucket; URLs are generated on read)
     const { error: updateError } = await supabase
       .from('documents')
-      .update({ signed_file_url: pdfPublicUrl, signed_pdf_url: pdfPublicUrl })
+      .update({ signed_file_url: pdfPath, signed_pdf_url: pdfPath })
       .eq('id', documentId);
 
     if (updateError) {
@@ -825,7 +810,7 @@ export async function generateSignedPdfFromPdf(documentId: string) {
     const totalTime = Date.now() - startTime;
     console.log(`[PDF-Sign] ✅ Complete! Total time: ${totalTime}ms`);
 
-    return { success: true, signedPdfUrl: pdfPublicUrl };
+    return { success: true, signedPdfUrl: pdfPath };
   } catch (error) {
     console.error('[PDF-Sign] ❌ Unexpected error:', error);
     return { error: 'An unexpected error occurred' };
@@ -916,8 +901,6 @@ export async function getDocumentFileSignedUrl(
   error?: string;
 }> {
   try {
-    // Use service role to bypass RLS for signed URL generation
-    const supabaseService = createServiceSupabase();
     const supabase = await createServerSupabase();
 
     // Get document
@@ -936,17 +919,19 @@ export async function getDocumentFileSignedUrl(
       return { signedUrl: null, error: "Document already completed" };
     }
 
-    // Generate signed URL (1 hour validity) using service role to bypass RLS
-    const { data, error: signError } = await supabaseService.storage
-      .from("documents")
-      .createSignedUrl(document.file_url, 3600);
+    // Generate signed URL (1 hour validity)
+    const { url, error: signError } = await getStorage().createSignedDownloadUrl(
+      "documents",
+      document.file_url,
+      { expiresIn: 3600 }
+    );
 
-    if (signError || !data) {
+    if (signError || !url) {
       console.error("Error creating signed URL:", signError);
       return { signedUrl: null, error: "Failed to generate signed URL" };
     }
 
-    return { signedUrl: data.signedUrl };
+    return { signedUrl: url };
   } catch (error) {
     console.error("Get document file signed URL error:", error);
     return { signedUrl: null, error: "An unexpected error occurred" };
@@ -1208,19 +1193,20 @@ export async function getSignedDocumentUrls(documentId: string): Promise<{
       return trimmed;
     };
 
-    const storage = supabase.storage.from("signed-documents");
+    const storage = getStorage();
 
     if (document.signed_file_url) {
       const filePath = extractPath(document.signed_file_url);
       if (filePath) {
-        const { data, error: previewError } = await storage.createSignedUrl(
+        const { url, error: previewError } = await storage.createSignedDownloadUrl(
+          "signed-documents",
           filePath,
-          3600
+          { expiresIn: 3600 }
         );
         if (previewError) {
           console.error("Error creating preview URL:", previewError);
         } else {
-          previewUrl = data?.signedUrl ?? null;
+          previewUrl = url;
         }
       }
     }
@@ -1231,15 +1217,15 @@ export async function getSignedDocumentUrls(documentId: string): Promise<{
         const originalName =
           document.filename.replace(/\.[^/.]+$/, "") || document.filename;
         const downloadName = `서명완료_${originalName}.pdf`;
-        const { data, error: downloadError } = await storage.createSignedUrl(
+        const { url, error: downloadError } = await storage.createSignedDownloadUrl(
+          "signed-documents",
           pdfPath,
-          3600,
-          { download: downloadName }
+          { expiresIn: 3600, downloadName }
         );
         if (downloadError) {
           console.error("Error creating download URL:", downloadError);
         } else {
-          downloadUrl = data?.signedUrl ?? null;
+          downloadUrl = url;
         }
       }
     }
@@ -1250,15 +1236,15 @@ export async function getSignedDocumentUrls(documentId: string): Promise<{
       if (filePath) {
         const originalName = document.filename.replace(/\.[^/.]+$/, "");
         const fallbackName = `서명완료_${originalName}.png`;
-        const { data, error: fallbackError } = await storage.createSignedUrl(
+        const { url, error: fallbackError } = await storage.createSignedDownloadUrl(
+          "signed-documents",
           filePath,
-          3600,
-          { download: fallbackName }
+          { expiresIn: 3600, downloadName: fallbackName }
         );
         if (fallbackError) {
           console.error("Error creating fallback download URL:", fallbackError);
         } else {
-          downloadUrl = data?.signedUrl ?? null;
+          downloadUrl = url;
         }
       }
     }
@@ -1367,16 +1353,18 @@ export async function getSignedDocumentUrlForSigner(
     const downloadName = `서명완료_${originalName}.${isPdf ? "pdf" : "png"}`;
 
     // 4. Issue short-lived (5 min) signed URL with download disposition
-    const { data, error: urlError } = await supabaseService.storage
-      .from("signed-documents")
-      .createSignedUrl(path, 300, { download: downloadName });
+    const { url, error: urlError } = await getStorage().createSignedDownloadUrl(
+      "signed-documents",
+      path,
+      { expiresIn: 300, downloadName }
+    );
 
-    if (urlError || !data) {
+    if (urlError || !url) {
       console.error("Error creating signer download URL:", urlError);
       return { downloadUrl: null, error: "Failed to generate download URL" };
     }
 
-    return { downloadUrl: data.signedUrl };
+    return { downloadUrl: url };
   } catch (error) {
     console.error("Get signer download URL error:", error);
     return { downloadUrl: null, error: "An unexpected error occurred" };
@@ -1472,22 +1460,22 @@ export async function getSignedDocumentBundleForSigner(
       return { error: "Signed document not available" };
     }
 
-    const storage = supabaseService.storage.from("signed-documents");
+    const storage = getStorage();
 
     // 4a. Single document → direct signed URL (no zip)
     if (completed.length === 1) {
       const { path, isPdf, baseName } = completed[0];
       const downloadName = `서명완료_${baseName}.${isPdf ? "pdf" : "png"}`;
-      const { data, error: urlError } = await storage.createSignedUrl(
+      const { url, error: urlError } = await storage.createSignedDownloadUrl(
+        "signed-documents",
         path,
-        300,
-        { download: downloadName }
+        { expiresIn: 300, downloadName }
       );
-      if (urlError || !data) {
+      if (urlError || !url) {
         console.error("Error creating signer download URL:", urlError);
         return { error: "Failed to generate download URL" };
       }
-      return { downloadUrl: data.signedUrl };
+      return { downloadUrl: url };
     }
 
     // 4b. Multiple documents → zip archive
@@ -1496,12 +1484,14 @@ export async function getSignedDocumentBundleForSigner(
     const usedNames = new Set<string>();
 
     for (const { path, isPdf, baseName } of completed) {
-      const { data: blob, error: dlError } = await storage.download(path);
-      if (dlError || !blob) {
+      const { data: bytes, error: dlError } = await storage.download(
+        "signed-documents",
+        path
+      );
+      if (dlError || !bytes) {
         console.error(`Failed to download ${path} for zip:`, dlError);
         continue;
       }
-      const bytes = new Uint8Array(await blob.arrayBuffer());
       let name = `서명완료_${baseName}.${isPdf ? "pdf" : "png"}`;
       let counter = 2;
       while (usedNames.has(name)) {
@@ -1629,9 +1619,10 @@ export async function deleteDocument(documentId: string): Promise<{
       if (document.file_url) {
         try {
           // file_url now contains the storage path: {user_id}/{filename}
-          const { error: storageError } = await supabase.storage
-            .from("documents")
-            .remove([document.file_url]);
+          const { error: storageError } = await getStorage().remove(
+            "documents",
+            [document.file_url]
+          );
 
           if (storageError) {
             console.error("⚠️ SERVER: Delete file error:", storageError);

--- a/app/actions/template-actions.ts
+++ b/app/actions/template-actions.ts
@@ -392,6 +392,50 @@ export async function getTemplateById(templateId: string): Promise<{
 }
 
 /**
+ * Owner-scoped presigned URL for a template's source file (for preview).
+ * Replaces client-side RLS storage.download.
+ */
+export async function getOwnedTemplateFileUrl(templateId: string): Promise<{
+  url: string | null;
+  error?: string;
+}> {
+  try {
+    const supabase = await createServerSupabase();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return { url: null, error: "User not authenticated" };
+    }
+
+    const { data: template, error } = await supabase
+      .from("document_templates")
+      .select("id, file_url")
+      .eq("id", templateId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (error || !template?.file_url) {
+      return { url: null, error: "Template not found" };
+    }
+
+    const { url, error: urlError } = await getStorage().createSignedDownloadUrl(
+      "documents",
+      template.file_url,
+      { expiresIn: 3600 }
+    );
+    if (urlError || !url) {
+      return { url: null, error: urlError ?? "Failed to generate URL" };
+    }
+    return { url };
+  } catch (error) {
+    console.error("Get owned template file URL error:", error);
+    return { url: null, error: "An unexpected error occurred" };
+  }
+}
+
+/**
  * Soft-delete a template (keeps storage cleanup best-effort).
  */
 export async function deleteTemplate(templateId: string): Promise<{

--- a/app/actions/template-actions.ts
+++ b/app/actions/template-actions.ts
@@ -22,6 +22,7 @@ import {
   buildTemplateAreaInserts,
 } from "@/lib/templates/clone";
 import { getCurrentSubscription } from "./subscription-actions";
+import { getStorage } from "@/lib/storage";
 
 /**
  * Gate the template feature to Pro / Enterprise plans.
@@ -121,9 +122,12 @@ export async function createTemplate(formData: FormData): Promise<{
     const ext = extractFileExtension(file.name) || (isPdf ? "pdf" : "png");
     const filePath = buildTemplateStoragePath(user.id, ext, randomUUID());
 
-    const { error: uploadError } = await supabase.storage
-      .from("documents")
-      .upload(filePath, file);
+    const { error: uploadError } = await getStorage().upload(
+      "documents",
+      filePath,
+      file,
+      { contentType: file.type }
+    );
 
     if (uploadError) {
       console.error("Template upload error:", uploadError);
@@ -147,7 +151,7 @@ export async function createTemplate(formData: FormData): Promise<{
     if (dbError || !template) {
       console.error("Template DB error:", dbError);
       // Rollback uploaded file
-      await supabase.storage.from("documents").remove([filePath]);
+      await getStorage().remove("documents", [filePath]);
       return { error: "Failed to create template record" };
     }
 
@@ -470,11 +474,11 @@ export async function rollbackTemplateCreation(templateId: string): Promise<{
     const cleanupErrors: string[] = [];
 
     if (template.file_url) {
-      const { error: storageError } = await serviceSupabase.storage
-        .from("documents")
-        .remove([template.file_url]);
+      const { error: storageError } = await getStorage().remove("documents", [
+        template.file_url,
+      ]);
       if (storageError) {
-        cleanupErrors.push(`storage: ${storageError.message}`);
+        cleanupErrors.push(`storage: ${storageError}`);
       }
     }
 
@@ -560,9 +564,11 @@ export async function publishFromTemplate(
       randomUUID()
     );
 
-    const { error: copyError } = await supabase.storage
-      .from("documents")
-      .copy(fullTemplate.file_url, newFilePath);
+    const { error: copyError } = await getStorage().copy(
+      "documents",
+      fullTemplate.file_url,
+      newFilePath
+    );
 
     if (copyError) {
       console.error("Template file copy error:", copyError);
@@ -585,7 +591,7 @@ export async function publishFromTemplate(
 
     if (docError || !document) {
       console.error("Cloned document insert error:", docError);
-      await supabase.storage.from("documents").remove([newFilePath]);
+      await getStorage().remove("documents", [newFilePath]);
       return { error: "Failed to create document from template" };
     }
 
@@ -601,7 +607,7 @@ export async function publishFromTemplate(
         console.error("Failed to deduct credit:", creditError);
         await decrementDocumentCreated();
         await supabase.from("documents").delete().eq("id", document.id);
-        await supabase.storage.from("documents").remove([newFilePath]);
+        await getStorage().remove("documents", [newFilePath]);
         return { error: "크레딧 차감 실패" };
       }
       creditDeducted = true;
@@ -614,7 +620,7 @@ export async function publishFromTemplate(
         await refundCredit("create", document.id);
       }
       await supabase.from("documents").delete().eq("id", document.id);
-      await supabase.storage.from("documents").remove([newFilePath]);
+      await getStorage().remove("documents", [newFilePath]);
     };
 
     // Clone signature areas as pending signatures

--- a/lib/storage/dual-provider.ts
+++ b/lib/storage/dual-provider.ts
@@ -1,0 +1,100 @@
+import { R2StorageProvider } from "./r2-provider";
+import { SupabaseStorageProvider } from "./supabase-provider";
+import type {
+  StorageProvider,
+  StorageBucket,
+  SignedDownloadOptions,
+  SignedUploadResult,
+  StorageDownload,
+} from "./types";
+
+/**
+ * Zero-downtime migration provider (strangler pattern).
+ * - writes: R2 (primary, required) + Supabase (mirror, best-effort)
+ * - reads:  R2 first, fall back to Supabase when the object isn't in R2 yet
+ * - presigned upload: R2 only (the signed PNG is transient; server rebuilds it)
+ *
+ * Used during Phase 1 so both stores stay populated and historical data keeps
+ * serving from Supabase until the backfill completes.
+ */
+export class DualStorageProvider implements StorageProvider {
+  readonly name = "dual" as const;
+  private readonly r2 = new R2StorageProvider();
+  private readonly sb = new SupabaseStorageProvider();
+
+  async upload(
+    bucket: StorageBucket,
+    key: string,
+    body: Blob | ArrayBuffer | Uint8Array | Buffer,
+    opts?: { contentType?: string; upsert?: boolean }
+  ): Promise<{ error?: string }> {
+    const primary = await this.r2.upload(bucket, key, body, opts);
+    if (primary.error) return primary; // R2 is the source of truth
+    // Mirror to Supabase (upsert) so rollback stays possible; non-fatal.
+    const mirror = await this.sb.upload(bucket, key, body, {
+      ...opts,
+      upsert: true,
+    });
+    if (mirror.error) {
+      console.warn(`[dual] Supabase mirror upload failed for ${bucket}/${key}:`, mirror.error);
+    }
+    return {};
+  }
+
+  async download(bucket: StorageBucket, key: string): Promise<StorageDownload> {
+    const primary = await this.r2.download(bucket, key);
+    if (primary.data) return primary;
+    return this.sb.download(bucket, key);
+  }
+
+  async createSignedDownloadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: SignedDownloadOptions
+  ): Promise<{ url: string | null; error?: string }> {
+    if (await this.r2.exists(bucket, key)) {
+      return this.r2.createSignedDownloadUrl(bucket, key, opts);
+    }
+    return this.sb.createSignedDownloadUrl(bucket, key, opts);
+  }
+
+  async createSignedUploadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: { expiresIn?: number }
+  ): Promise<{ result: SignedUploadResult | null; error?: string }> {
+    // Transient intermediate upload — R2 only.
+    return this.r2.createSignedUploadUrl(bucket, key, opts);
+  }
+
+  async remove(bucket: StorageBucket, keys: string[]): Promise<{ error?: string }> {
+    const [r2Res, sbRes] = await Promise.all([
+      this.r2.remove(bucket, keys),
+      this.sb.remove(bucket, keys),
+    ]);
+    return r2Res.error ? r2Res : sbRes;
+  }
+
+  async copy(
+    bucket: StorageBucket,
+    srcKey: string,
+    destKey: string
+  ): Promise<{ error?: string }> {
+    // Source may live in either store; download (with fallback) then dual-write.
+    const src = await this.download(bucket, srcKey);
+    if (!src.data) return { error: "Copy source not found" };
+    return this.upload(bucket, destKey, src.data, { contentType: src.contentType });
+  }
+
+  async list(
+    bucket: StorageBucket,
+    prefix: string
+  ): Promise<{ keys: string[]; error?: string }> {
+    const [r2Res, sbRes] = await Promise.all([
+      this.r2.list(bucket, prefix),
+      this.sb.list(bucket, prefix),
+    ]);
+    const keys = new Set([...(r2Res.keys ?? []), ...(sbRes.keys ?? [])]);
+    return { keys: [...keys] };
+  }
+}

--- a/lib/storage/dual-provider.ts
+++ b/lib/storage/dual-provider.ts
@@ -42,9 +42,15 @@ export class DualStorageProvider implements StorageProvider {
   }
 
   async download(bucket: StorageBucket, key: string): Promise<StorageDownload> {
-    const primary = await this.r2.download(bucket, key);
-    if (primary.data) return primary;
-    return this.sb.download(bucket, key);
+    // Only fall back to Supabase when the object is genuinely absent from R2.
+    // Real R2 errors (auth/network/config) must not silently serve stale data.
+    let inR2: boolean;
+    try {
+      inR2 = await this.r2.exists(bucket, key);
+    } catch (e) {
+      return { data: null, error: e instanceof Error ? e.message : "R2 error" };
+    }
+    return inR2 ? this.r2.download(bucket, key) : this.sb.download(bucket, key);
   }
 
   async createSignedDownloadUrl(
@@ -52,10 +58,15 @@ export class DualStorageProvider implements StorageProvider {
     key: string,
     opts?: SignedDownloadOptions
   ): Promise<{ url: string | null; error?: string }> {
-    if (await this.r2.exists(bucket, key)) {
-      return this.r2.createSignedDownloadUrl(bucket, key, opts);
+    let inR2: boolean;
+    try {
+      inR2 = await this.r2.exists(bucket, key);
+    } catch (e) {
+      return { url: null, error: e instanceof Error ? e.message : "R2 error" };
     }
-    return this.sb.createSignedDownloadUrl(bucket, key, opts);
+    return inR2
+      ? this.r2.createSignedDownloadUrl(bucket, key, opts)
+      : this.sb.createSignedDownloadUrl(bucket, key, opts);
   }
 
   async createSignedUploadUrl(
@@ -94,6 +105,10 @@ export class DualStorageProvider implements StorageProvider {
       this.r2.list(bucket, prefix),
       this.sb.list(bucket, prefix),
     ]);
+    // Surface partial failures so cleanup/account-deletion callers don't
+    // mistake an incomplete key set for the full listing.
+    if (r2Res.error) return { keys: [], error: r2Res.error };
+    if (sbRes.error) return { keys: [], error: sbRes.error };
     const keys = new Set([...(r2Res.keys ?? []), ...(sbRes.keys ?? [])]);
     return { keys: [...keys] };
   }

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,18 +1,26 @@
 import type { StorageProvider } from "./types";
 import { SupabaseStorageProvider } from "./supabase-provider";
 import { R2StorageProvider } from "./r2-provider";
+import { DualStorageProvider } from "./dual-provider";
 
 export type * from "./types";
 
 let cached: StorageProvider | null = null;
 
 /**
- * Returns the active storage provider based on STORAGE_PROVIDER env
- * ("supabase" | "r2"). Defaults to Supabase for safe rollback.
+ * Returns the active storage provider based on STORAGE_PROVIDER env:
+ * - "supabase" (default): Supabase only
+ * - "dual": write both, read R2 → Supabase fallback (zero-downtime migration)
+ * - "r2": R2 only (post-cutover)
  */
 export function getStorage(): StorageProvider {
   if (cached) return cached;
   const provider = (process.env.STORAGE_PROVIDER || "supabase").toLowerCase();
-  cached = provider === "r2" ? new R2StorageProvider() : new SupabaseStorageProvider();
+  cached =
+    provider === "r2"
+      ? new R2StorageProvider()
+      : provider === "dual"
+        ? new DualStorageProvider()
+        : new SupabaseStorageProvider();
   return cached;
 }

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -16,11 +16,21 @@ let cached: StorageProvider | null = null;
 export function getStorage(): StorageProvider {
   if (cached) return cached;
   const provider = (process.env.STORAGE_PROVIDER || "supabase").toLowerCase();
-  cached =
-    provider === "r2"
-      ? new R2StorageProvider()
-      : provider === "dual"
-        ? new DualStorageProvider()
-        : new SupabaseStorageProvider();
+  switch (provider) {
+    case "r2":
+      cached = new R2StorageProvider();
+      break;
+    case "dual":
+      cached = new DualStorageProvider();
+      break;
+    case "supabase":
+      cached = new SupabaseStorageProvider();
+      break;
+    default:
+      // Fail fast: a typo must not silently split writes across providers.
+      throw new Error(
+        `Invalid STORAGE_PROVIDER "${process.env.STORAGE_PROVIDER}". Expected "supabase" | "dual" | "r2".`
+      );
+  }
   return cached;
 }

--- a/lib/storage/index.ts
+++ b/lib/storage/index.ts
@@ -1,0 +1,18 @@
+import type { StorageProvider } from "./types";
+import { SupabaseStorageProvider } from "./supabase-provider";
+import { R2StorageProvider } from "./r2-provider";
+
+export type * from "./types";
+
+let cached: StorageProvider | null = null;
+
+/**
+ * Returns the active storage provider based on STORAGE_PROVIDER env
+ * ("supabase" | "r2"). Defaults to Supabase for safe rollback.
+ */
+export function getStorage(): StorageProvider {
+  if (cached) return cached;
+  const provider = (process.env.STORAGE_PROVIDER || "supabase").toLowerCase();
+  cached = provider === "r2" ? new R2StorageProvider() : new SupabaseStorageProvider();
+  return cached;
+}

--- a/lib/storage/r2-provider.ts
+++ b/lib/storage/r2-provider.ts
@@ -1,0 +1,185 @@
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectsCommand,
+  CopyObjectCommand,
+  ListObjectsV2Command,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type {
+  StorageProvider,
+  StorageBucket,
+  SignedDownloadOptions,
+  SignedUploadResult,
+  StorageDownload,
+} from "./types";
+
+/**
+ * Cloudflare R2 implementation via the S3-compatible API.
+ * Access control is enforced by the calling server action; all objects are
+ * private and only reachable through short-lived presigned URLs.
+ */
+export class R2StorageProvider implements StorageProvider {
+  readonly name = "r2" as const;
+  private readonly s3: S3Client;
+
+  constructor() {
+    this.s3 = new S3Client({
+      region: "auto",
+      endpoint: process.env.R2_ENDPOINT!,
+      credentials: {
+        accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+      },
+    });
+  }
+
+  private physicalBucket(bucket: StorageBucket): string {
+    return bucket === "documents"
+      ? process.env.R2_BUCKET_DOCUMENTS || "documents"
+      : process.env.R2_BUCKET_SIGNED || "signed-documents";
+  }
+
+  private static contentDisposition(name: string): string {
+    // RFC 5987 encoding so non-ASCII (Korean) filenames survive.
+    return `attachment; filename*=UTF-8''${encodeURIComponent(name)}`;
+  }
+
+  private static async toBytes(
+    body: Blob | ArrayBuffer | Uint8Array | Buffer
+  ): Promise<Uint8Array> {
+    // Buffer is a Uint8Array subclass, so this catches it too.
+    if (body instanceof Uint8Array) return body;
+    if (body instanceof ArrayBuffer) return new Uint8Array(body);
+    return new Uint8Array(await body.arrayBuffer());
+  }
+
+  async upload(
+    bucket: StorageBucket,
+    key: string,
+    body: Blob | ArrayBuffer | Uint8Array | Buffer,
+    opts?: { contentType?: string }
+  ): Promise<{ error?: string }> {
+    try {
+      const bytes = await R2StorageProvider.toBytes(body);
+      await this.s3.send(
+        new PutObjectCommand({
+          Bucket: this.physicalBucket(bucket),
+          Key: key,
+          Body: bytes,
+          ContentType: opts?.contentType,
+        })
+      );
+      return {};
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : "Upload failed" };
+    }
+  }
+
+  async download(bucket: StorageBucket, key: string): Promise<StorageDownload> {
+    try {
+      const res = await this.s3.send(
+        new GetObjectCommand({ Bucket: this.physicalBucket(bucket), Key: key })
+      );
+      const bytes = await res.Body!.transformToByteArray();
+      return { data: bytes, contentType: res.ContentType };
+    } catch (e) {
+      return { data: null, error: e instanceof Error ? e.message : "Download failed" };
+    }
+  }
+
+  async createSignedDownloadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: SignedDownloadOptions
+  ): Promise<{ url: string | null; error?: string }> {
+    try {
+      const command = new GetObjectCommand({
+        Bucket: this.physicalBucket(bucket),
+        Key: key,
+        ResponseContentDisposition: opts?.downloadName
+          ? R2StorageProvider.contentDisposition(opts.downloadName)
+          : undefined,
+      });
+      const url = await getSignedUrl(this.s3, command, {
+        expiresIn: opts?.expiresIn ?? 300,
+      });
+      return { url };
+    } catch (e) {
+      return { url: null, error: e instanceof Error ? e.message : "Failed to sign URL" };
+    }
+  }
+
+  async createSignedUploadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: { expiresIn?: number }
+  ): Promise<{ result: SignedUploadResult | null; error?: string }> {
+    try {
+      const command = new PutObjectCommand({
+        Bucket: this.physicalBucket(bucket),
+        Key: key,
+      });
+      const url = await getSignedUrl(this.s3, command, {
+        expiresIn: opts?.expiresIn ?? 300,
+      });
+      return { result: { url, key, provider: "r2" } };
+    } catch (e) {
+      return { result: null, error: e instanceof Error ? e.message : "Failed to sign upload" };
+    }
+  }
+
+  async remove(bucket: StorageBucket, keys: string[]): Promise<{ error?: string }> {
+    if (keys.length === 0) return {};
+    try {
+      await this.s3.send(
+        new DeleteObjectsCommand({
+          Bucket: this.physicalBucket(bucket),
+          Delete: { Objects: keys.map((Key) => ({ Key })) },
+        })
+      );
+      return {};
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : "Delete failed" };
+    }
+  }
+
+  async copy(
+    bucket: StorageBucket,
+    srcKey: string,
+    destKey: string
+  ): Promise<{ error?: string }> {
+    try {
+      const b = this.physicalBucket(bucket);
+      await this.s3.send(
+        new CopyObjectCommand({
+          Bucket: b,
+          CopySource: `${b}/${encodeURIComponent(srcKey)}`,
+          Key: destKey,
+        })
+      );
+      return {};
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : "Copy failed" };
+    }
+  }
+
+  async list(
+    bucket: StorageBucket,
+    prefix: string
+  ): Promise<{ keys: string[]; error?: string }> {
+    try {
+      const res = await this.s3.send(
+        new ListObjectsV2Command({
+          Bucket: this.physicalBucket(bucket),
+          Prefix: prefix,
+        })
+      );
+      const keys = (res.Contents ?? []).map((o) => o.Key!).filter(Boolean);
+      return { keys };
+    } catch (e) {
+      return { keys: [], error: e instanceof Error ? e.message : "List failed" };
+    }
+  }
+}

--- a/lib/storage/r2-provider.ts
+++ b/lib/storage/r2-provider.ts
@@ -145,12 +145,17 @@ export class R2StorageProvider implements StorageProvider {
   async remove(bucket: StorageBucket, keys: string[]): Promise<{ error?: string }> {
     if (keys.length === 0) return {};
     try {
-      await this.s3.send(
-        new DeleteObjectsCommand({
-          Bucket: this.physicalBucket(bucket),
-          Delete: { Objects: keys.map((Key) => ({ Key })) },
-        })
-      );
+      const b = this.physicalBucket(bucket);
+      // DeleteObjects allows max 1,000 keys per request.
+      for (let i = 0; i < keys.length; i += 1000) {
+        const chunk = keys.slice(i, i + 1000);
+        await this.s3.send(
+          new DeleteObjectsCommand({
+            Bucket: b,
+            Delete: { Objects: chunk.map((Key) => ({ Key })) },
+          })
+        );
+      }
       return {};
     } catch (e) {
       return { error: e instanceof Error ? e.message : "Delete failed" };
@@ -182,13 +187,21 @@ export class R2StorageProvider implements StorageProvider {
     prefix: string
   ): Promise<{ keys: string[]; error?: string }> {
     try {
-      const res = await this.s3.send(
-        new ListObjectsV2Command({
-          Bucket: this.physicalBucket(bucket),
-          Prefix: prefix,
-        })
-      );
-      const keys = (res.Contents ?? []).map((o) => o.Key!).filter(Boolean);
+      const b = this.physicalBucket(bucket);
+      const keys: string[] = [];
+      let token: string | undefined;
+      // Page through continuation tokens (ListObjectsV2 caps at 1,000/page).
+      do {
+        const res = await this.s3.send(
+          new ListObjectsV2Command({
+            Bucket: b,
+            Prefix: prefix,
+            ContinuationToken: token,
+          })
+        );
+        for (const o of res.Contents ?? []) if (o.Key) keys.push(o.Key);
+        token = res.IsTruncated ? res.NextContinuationToken : undefined;
+      } while (token);
       return { keys };
     } catch (e) {
       return { keys: [], error: e instanceof Error ? e.message : "List failed" };

--- a/lib/storage/r2-provider.ts
+++ b/lib/storage/r2-provider.ts
@@ -5,6 +5,7 @@ import {
   DeleteObjectsCommand,
   CopyObjectCommand,
   ListObjectsV2Command,
+  HeadObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type {
@@ -74,6 +75,17 @@ export class R2StorageProvider implements StorageProvider {
       return {};
     } catch (e) {
       return { error: e instanceof Error ? e.message : "Upload failed" };
+    }
+  }
+
+  async exists(bucket: StorageBucket, key: string): Promise<boolean> {
+    try {
+      await this.s3.send(
+        new HeadObjectCommand({ Bucket: this.physicalBucket(bucket), Key: key })
+      );
+      return true;
+    } catch {
+      return false;
     }
   }
 

--- a/lib/storage/r2-provider.ts
+++ b/lib/storage/r2-provider.ts
@@ -84,8 +84,13 @@ export class R2StorageProvider implements StorageProvider {
         new HeadObjectCommand({ Bucket: this.physicalBucket(bucket), Key: key })
       );
       return true;
-    } catch {
-      return false;
+    } catch (e: any) {
+      const status = e?.$metadata?.httpStatusCode;
+      if (status === 404 || e?.name === "NotFound" || e?.name === "NoSuchKey") {
+        return false;
+      }
+      // Surface auth/network/config errors instead of masking them as "absent".
+      throw e;
     }
   }
 

--- a/lib/storage/supabase-provider.ts
+++ b/lib/storage/supabase-provider.ts
@@ -1,0 +1,115 @@
+import { createServiceSupabase } from "@/lib/supabase/server";
+import type {
+  StorageProvider,
+  StorageBucket,
+  SignedDownloadOptions,
+  SignedUploadResult,
+  StorageDownload,
+} from "./types";
+
+/**
+ * Supabase Storage implementation (service role — access control is enforced
+ * by the calling server action, not by storage RLS).
+ */
+export class SupabaseStorageProvider implements StorageProvider {
+  readonly name = "supabase" as const;
+
+  private client() {
+    return createServiceSupabase().storage;
+  }
+
+  async upload(
+    bucket: StorageBucket,
+    key: string,
+    body: Blob | ArrayBuffer | Uint8Array | Buffer,
+    opts?: { contentType?: string; upsert?: boolean }
+  ): Promise<{ error?: string }> {
+    const { error } = await this.client()
+      .from(bucket)
+      .upload(key, body as Blob, {
+        contentType: opts?.contentType,
+        upsert: opts?.upsert ?? false,
+      });
+    return error ? { error: error.message } : {};
+  }
+
+  async download(bucket: StorageBucket, key: string): Promise<StorageDownload> {
+    const { data, error } = await this.client().from(bucket).download(key);
+    if (error || !data) {
+      return { data: null, error: error?.message ?? "Download failed" };
+    }
+    const bytes = new Uint8Array(await data.arrayBuffer());
+    return { data: bytes, contentType: data.type || undefined };
+  }
+
+  async createSignedDownloadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: SignedDownloadOptions
+  ): Promise<{ url: string | null; error?: string }> {
+    const { data, error } = await this.client()
+      .from(bucket)
+      .createSignedUrl(
+        key,
+        opts?.expiresIn ?? 300,
+        opts?.downloadName ? { download: opts.downloadName } : undefined
+      );
+    if (error || !data) {
+      return { url: null, error: error?.message ?? "Failed to sign URL" };
+    }
+    return { url: data.signedUrl };
+  }
+
+  async createSignedUploadUrl(
+    bucket: StorageBucket,
+    key: string
+  ): Promise<{ result: SignedUploadResult | null; error?: string }> {
+    const { data, error } = await this.client()
+      .from(bucket)
+      .createSignedUploadUrl(key);
+    if (error || !data) {
+      return { result: null, error: error?.message ?? "Failed to sign upload" };
+    }
+    return {
+      result: {
+        url: data.signedUrl,
+        key,
+        provider: "supabase",
+        token: data.token,
+      },
+    };
+  }
+
+  async remove(bucket: StorageBucket, keys: string[]): Promise<{ error?: string }> {
+    if (keys.length === 0) return {};
+    const { error } = await this.client().from(bucket).remove(keys);
+    return error ? { error: error.message } : {};
+  }
+
+  async copy(
+    bucket: StorageBucket,
+    srcKey: string,
+    destKey: string
+  ): Promise<{ error?: string }> {
+    const { error } = await this.client().from(bucket).copy(srcKey, destKey);
+    return error ? { error: error.message } : {};
+  }
+
+  async list(
+    bucket: StorageBucket,
+    prefix: string
+  ): Promise<{ keys: string[]; error?: string }> {
+    // Split prefix into folder + name-search to match Supabase's list API.
+    const slash = prefix.lastIndexOf("/");
+    const folder = slash >= 0 ? prefix.slice(0, slash) : "";
+    const search = slash >= 0 ? prefix.slice(slash + 1) : prefix;
+    const { data, error } = await this.client()
+      .from(bucket)
+      .list(folder, search ? { search } : undefined);
+    if (error) return { keys: [], error: error.message };
+    const keys = (data ?? []).map((f) =>
+      folder ? `${folder}/${f.name}` : f.name
+    );
+    return { keys };
+  }
+}

--- a/lib/storage/supabase-provider.ts
+++ b/lib/storage/supabase-provider.ts
@@ -103,13 +103,22 @@ export class SupabaseStorageProvider implements StorageProvider {
     const slash = prefix.lastIndexOf("/");
     const folder = slash >= 0 ? prefix.slice(0, slash) : "";
     const search = slash >= 0 ? prefix.slice(slash + 1) : prefix;
-    const { data, error } = await this.client()
-      .from(bucket)
-      .list(folder, search ? { search } : undefined);
-    if (error) return { keys: [], error: error.message };
-    const keys = (data ?? []).map((f) =>
-      folder ? `${folder}/${f.name}` : f.name
-    );
+
+    // Supabase list() defaults to 100 items; page explicitly for full enumeration.
+    const client = this.client().from(bucket);
+    const pageSize = 1000;
+    const keys: string[] = [];
+    for (let offset = 0; ; offset += pageSize) {
+      const { data, error } = await client.list(folder, {
+        limit: pageSize,
+        offset,
+        ...(search ? { search } : {}),
+      });
+      if (error) return { keys: [], error: error.message };
+      if (!data || data.length === 0) break;
+      for (const f of data) keys.push(folder ? `${folder}/${f.name}` : f.name);
+      if (data.length < pageSize) break;
+    }
     return { keys };
   }
 }

--- a/lib/storage/types.ts
+++ b/lib/storage/types.ts
@@ -29,7 +29,7 @@ export interface StorageDownload {
 }
 
 export interface StorageProvider {
-  readonly name: "supabase" | "r2";
+  readonly name: "supabase" | "r2" | "dual";
 
   upload(
     bucket: StorageBucket,

--- a/lib/storage/types.ts
+++ b/lib/storage/types.ts
@@ -1,0 +1,65 @@
+// Storage abstraction — provider-agnostic interface.
+// Logical bucket names are stable across providers; each provider maps them
+// to its own physical bucket.
+
+export type StorageBucket = "documents" | "signed-documents";
+
+export interface SignedDownloadOptions {
+  /** URL validity in seconds (default 300). */
+  expiresIn?: number;
+  /** If set, forces a download with this filename (Content-Disposition). */
+  downloadName?: string;
+}
+
+export interface SignedUploadResult {
+  /** URL the client uploads to. */
+  url: string;
+  /** Storage key the file will land at. */
+  key: string;
+  /** Provider discriminator so the client uploads with the right method. */
+  provider: "supabase" | "r2";
+  /** Supabase signed-upload token (Supabase provider only). */
+  token?: string;
+}
+
+export interface StorageDownload {
+  data: Uint8Array | null;
+  contentType?: string;
+  error?: string;
+}
+
+export interface StorageProvider {
+  readonly name: "supabase" | "r2";
+
+  upload(
+    bucket: StorageBucket,
+    key: string,
+    body: Blob | ArrayBuffer | Uint8Array | Buffer,
+    opts?: { contentType?: string; upsert?: boolean }
+  ): Promise<{ error?: string }>;
+
+  download(bucket: StorageBucket, key: string): Promise<StorageDownload>;
+
+  createSignedDownloadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: SignedDownloadOptions
+  ): Promise<{ url: string | null; error?: string }>;
+
+  createSignedUploadUrl(
+    bucket: StorageBucket,
+    key: string,
+    opts?: { expiresIn?: number }
+  ): Promise<{ result: SignedUploadResult | null; error?: string }>;
+
+  remove(bucket: StorageBucket, keys: string[]): Promise<{ error?: string }>;
+
+  copy(
+    bucket: StorageBucket,
+    srcKey: string,
+    destKey: string
+  ): Promise<{ error?: string }>;
+
+  /** List object keys under a prefix (used for cleanup). */
+  list(bucket: StorageBucket, prefix: string): Promise<{ keys: string[]; error?: string }>;
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "postinstall": "node scripts/build-pdf-worker.mjs"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1077.0",
+    "@aws-sdk/s3-request-presigner": "^3.1077.0",
     "@hookform/resolvers": "^3.9.1",
     "@paddle/paddle-js": "^1.4.2",
     "@paddle/paddle-node-sdk": "^3.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1077.0
+        version: 3.1077.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1077.0
+        version: 3.1077.0
       '@hookform/resolvers':
         specifier: ^3.9.1
         version: 3.10.0(react-hook-form@7.62.0(react@18.3.1))
@@ -243,6 +249,82 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@aws-sdk/checksums@3.1000.10':
+    resolution: {integrity: sha512-OUNjNcyA8Ai2OdlRUxW5jHUf6XJmqqZk3UddL+mDiUCtXrVqdmIHHkdDFWBlBRjhore/3ZBMgRXgcS0ggtvD0Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1077.0':
+    resolution: {integrity: sha512-yWK6jOMrMUgGarXlrQaAopWXva20NaOqTPApuE68SzsBFQ57fQ5E13BKUPLwtPgymk+8L6vG/O4h7Q30IBYr2w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.25':
+    resolution: {integrity: sha512-fJFkx6u6wCqGMV/v6EAxiwa2UzEukbvr1hNPv4MrD3yj4IFz011jZg42/eSTOP/u5kJ0tlILqEjCWtT8GiKZvA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.51':
+    resolution: {integrity: sha512-Xo+/zf5k5pZdo53X8aVXN4MJGfU/M1P7yMM/GbNY/x9fyRZGEzjhKqW38GA0FSQQ9TYKs+bfPyz5ja4bi6pjTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.53':
+    resolution: {integrity: sha512-7E9oFUcf9YWe+ttGiWhe/cCSI+pswwelzgQMoKXgPJi1AIfS27TK6et5ZULqEqHu30zbN+jh1RqlwcXqY/aXyg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.58':
+    resolution: {integrity: sha512-MPr0hD8pyDGfF3dWXvFOILhcKTB9ptqJOJK9JEuDQzpc2HgKisY16eR7IrKUXxSbz8LZj+LHz/CS8Y5G1ai7yw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.57':
+    resolution: {integrity: sha512-kPWc/SCrl9agKeywxKwPEoQHanWag0LcNQrcZpEQpjNifkxq6tQENhgrrS9al317CF6yytyihlX+FhPHlk0QjA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.60':
+    resolution: {integrity: sha512-hE2hIBJQjCDRx8TbSqpVQ+/o2mIrJZQZbQ3LlwE2bJf7z47x5GmhcvGwZPqJH7Oq//SzTXEBGSZ4qSpK3yPbhw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.51':
+    resolution: {integrity: sha512-081dD2RlnmY+G05v6E73KfACvDjPjnttrLjGHE2SSglbID25UcuijbWpL4g+XR5T2Kl4oIJoVBXi64s+2f009Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.57':
+    resolution: {integrity: sha512-dC7ZyX3EHKHLOeVUEDzzGvk0L1s6N06YDrau7P0rGXL/j1cO+DzN2w1x9vcEh7zljVCR3019f5mi1Th+GGTURw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.57':
+    resolution: {integrity: sha512-HtWM3FV2o7NJFJSUqFLBlxmV9RxQRHpzCvQaP1n1Qo4CxQSvwpJ8ERWHiLqXMFDgDXyELt+EZNFcpG6XQRcJbQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.56':
+    resolution: {integrity: sha512-VFLd7bT8ef48H2n2iDrY/w9EPpXLmC0v4NEriXy2vuTgEP/FrKqrcwi7eobhcOrdO37uLbMt5AWZlY55R2/xqg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.25':
+    resolution: {integrity: sha512-VpRQ3wR6l+fwRHV5veJL2ehtyQFrGyH/2CJG9DVtb8H3xyqqnZWSTSrq/CJJ7DvDlDgrPRiW2SkYA8pN6VWCFQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1077.0':
+    resolution: {integrity: sha512-gmj0nvnnuLDvXHekQNCTljcp/0XrQ1Mi6EpFYv6TF/u9oa4PugIhO5BpIDoKf4qvaQuOX+71E8KMkn9GS75dPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.37':
+    resolution: {integrity: sha512-u8qd064XsHzM0Mk+yH4IPKn/ZC9rdniEKs+neBHNlsPZirw3rcLvmrH4ImoKC4yF7A0I/MbcC3dseARnJLiAhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1077.0':
+    resolution: {integrity: sha512-sRUkfZ3fpOco95jZHsQUQiXvuIVLvCmWVclFg6dRFDyfsYs6Pdr/NuZ2+yJxeHN+6WAfDh2aZ8nlZntnvuhZUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.14':
+    resolution: {integrity: sha512-vH4pEu9YBEwr67yT+GVcmKX0GzfIrIYUn+MF5vXg9OspouVnAekuyVyawFvZHEK7WlcwVDwNrqI3ZBDUAiyu9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.32':
+    resolution: {integrity: sha512-2loKuOMRFDg1nwdni5AtJ9S5juVbRNPNsPC7tWTfkHyycPwACMhxepspUHi8GhvfNlL2cQo3sPMod1uib+KZ0w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1742,6 +1824,30 @@ packages:
     peerDependencies:
       webpack: '>=4.40.0'
 
+  '@smithy/core@3.28.0':
+    resolution: {integrity: sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.4':
+    resolution: {integrity: sha512-jT0WrDaM88L5na9FX1xRNywCS3B1n75wPY5Ksasjo0PHUtuI7d8FclksN1BbOSYTiaiKxUDqU23nUymH/V+AaQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.1':
+    resolution: {integrity: sha512-fW6l9rWoyk1iyzfuZaERnZLNjB6WIojgGm6Bo9Hpfpy3RUpltjLikNlxTsS/YtxVobcfbCGBuAncREYqT4hvqQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.1':
+    resolution: {integrity: sha512-m/f15di58P6NtLQ7eVEb5N19NdJWn+4c7zfkFHMT/i3JH7U8UtknpPoy8o2tm2R3OdliYvsvQhZHIfACQDqT+Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.0':
+    resolution: {integrity: sha512-IkPHQdbyoebSwBCuMTzJ/2oIhKVqiZZAZxQYSlpDZqq/WhJUpmdgbHvP7ItddxsPzcDUJeI0V4PNMSNtlZ0aqA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.0':
+    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2110,6 +2216,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
@@ -3626,6 +3735,180 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@aws-sdk/checksums@3.1000.10':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1077.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.10
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/credential-provider-node': 3.972.60
+      '@aws-sdk/middleware-sdk-s3': 3.972.56
+      '@aws-sdk/signature-v4-multi-region': 3.996.37
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/node-http-handler': 4.9.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.25':
+    dependencies:
+      '@aws-sdk/types': 3.973.14
+      '@aws-sdk/xml-builder': 3.972.32
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.28.0
+      '@smithy/signature-v4': 5.6.0
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/node-http-handler': 4.9.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.58':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/credential-provider-env': 3.972.51
+      '@aws-sdk/credential-provider-http': 3.972.53
+      '@aws-sdk/credential-provider-login': 3.972.57
+      '@aws-sdk/credential-provider-process': 3.972.51
+      '@aws-sdk/credential-provider-sso': 3.972.57
+      '@aws-sdk/credential-provider-web-identity': 3.972.57
+      '@aws-sdk/nested-clients': 3.997.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/credential-provider-imds': 4.4.4
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/nested-clients': 3.997.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.60':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.51
+      '@aws-sdk/credential-provider-http': 3.972.53
+      '@aws-sdk/credential-provider-ini': 3.972.58
+      '@aws-sdk/credential-provider-process': 3.972.51
+      '@aws-sdk/credential-provider-sso': 3.972.57
+      '@aws-sdk/credential-provider-web-identity': 3.972.57
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/credential-provider-imds': 4.4.4
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/nested-clients': 3.997.25
+      '@aws-sdk/token-providers': 3.1077.0
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/nested-clients': 3.997.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/signature-v4-multi-region': 3.996.37
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.25':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/signature-v4-multi-region': 3.996.37
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/node-http-handler': 4.9.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1077.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/signature-v4-multi-region': 3.996.37
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.37':
+    dependencies:
+      '@aws-sdk/types': 3.973.14
+      '@smithy/signature-v4': 5.6.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1077.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.25
+      '@aws-sdk/nested-clients': 3.997.25
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.14':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.32':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -5202,6 +5485,39 @@ snapshots:
       - encoding
       - supports-color
 
+  '@smithy/core@3.28.0':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.4':
+    dependencies:
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.1':
+    dependencies:
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.1':
+    dependencies:
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.0':
+    dependencies:
+      '@smithy/core': 3.28.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@supabase/auth-js@2.71.1':
@@ -5582,6 +5898,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bowser@2.14.1: {}
 
   brace-expansion@2.0.2:
     dependencies:

--- a/scripts/migrate-storage-to-r2.mjs
+++ b/scripts/migrate-storage-to-r2.mjs
@@ -1,0 +1,140 @@
+/**
+ * One-off migration: copy DB-referenced files from Supabase Storage to R2.
+ * Idempotent (skips objects already present in R2). Copy only — DB
+ * normalization of signed_* URL columns is done separately via SQL.
+ *
+ * Usage:
+ *   node scripts/migrate-storage-to-r2.mjs           # migrate
+ *   DRY_RUN=1 node scripts/migrate-storage-to-r2.mjs # report only
+ */
+import { readFileSync } from "node:fs";
+import { createClient } from "@supabase/supabase-js";
+import {
+  S3Client,
+  HeadObjectCommand,
+  PutObjectCommand,
+} from "@aws-sdk/client-s3";
+
+const env = Object.fromEntries(
+  readFileSync(new URL("../.env.local", import.meta.url), "utf8")
+    .split("\n")
+    .filter((l) => l.trim() && !l.trim().startsWith("#") && l.includes("="))
+    .map((l) => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i).trim(), l.slice(i + 1).trim().replace(/^["']|["']$/g, "")];
+    })
+);
+
+const DRY = !!process.env.DRY_RUN;
+const supabase = createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { persistSession: false },
+});
+const s3 = new S3Client({
+  region: "auto",
+  endpoint: env.R2_ENDPOINT,
+  credentials: {
+    accessKeyId: env.R2_ACCESS_KEY_ID,
+    secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+  },
+});
+const R2_BUCKET = {
+  documents: env.R2_BUCKET_DOCUMENTS || "documents",
+  "signed-documents": env.R2_BUCKET_SIGNED || "signed-documents",
+};
+
+function extractSignedKey(value) {
+  if (!value) return null;
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    try {
+      const parts = new URL(value).pathname.split("/");
+      const i = parts.indexOf("signed-documents");
+      return i === -1 ? null : parts.slice(i + 1).join("/");
+    } catch {
+      return null;
+    }
+  }
+  return value.startsWith("signed-documents/")
+    ? value.slice("signed-documents/".length)
+    : value;
+}
+
+async function collectKeys() {
+  const keys = { documents: new Set(), "signed-documents": new Set() };
+  const page = 1000;
+
+  // documents.file_url + signed_* (paginated)
+  for (let from = 0; ; from += page) {
+    const { data, error } = await supabase
+      .from("documents")
+      .select("file_url, signed_file_url, signed_pdf_url")
+      .range(from, from + page - 1);
+    if (error) throw error;
+    if (!data.length) break;
+    for (const d of data) {
+      if (d.file_url) keys.documents.add(d.file_url);
+      for (const s of [d.signed_pdf_url, d.signed_file_url]) {
+        const k = extractSignedKey(s);
+        if (k) keys["signed-documents"].add(k);
+      }
+    }
+    if (data.length < page) break;
+  }
+
+  // document_templates.file_url
+  for (let from = 0; ; from += page) {
+    const { data, error } = await supabase
+      .from("document_templates")
+      .select("file_url")
+      .range(from, from + page - 1);
+    if (error) throw error;
+    if (!data.length) break;
+    for (const t of data) if (t.file_url) keys.documents.add(t.file_url);
+    if (data.length < page) break;
+  }
+
+  return keys;
+}
+
+async function existsInR2(bucket, key) {
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: R2_BUCKET[bucket], Key: key }));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function migrateBucket(bucket, keys) {
+  let copied = 0, skipped = 0, missing = 0, failed = 0, bytes = 0;
+  for (const key of keys) {
+    if (await existsInR2(bucket, key)) { skipped++; continue; }
+    if (DRY) { copied++; continue; } // report as "to copy" without downloading
+    const { data, error } = await supabase.storage.from(bucket).download(key);
+    if (error || !data) { missing++; console.warn(`  ⚠️ source missing: ${bucket}/${key}`); continue; }
+    const buf = new Uint8Array(await data.arrayBuffer());
+    if (DRY) { copied++; bytes += buf.length; continue; }
+    try {
+      await s3.send(new PutObjectCommand({
+        Bucket: R2_BUCKET[bucket],
+        Key: key,
+        Body: buf,
+        ContentType: data.type || undefined,
+      }));
+      copied++; bytes += buf.length;
+    } catch (e) {
+      failed++; console.error(`  ❌ upload failed ${bucket}/${key}: ${e.message}`);
+    }
+  }
+  return { total: keys.size, copied, skipped, missing, failed, mb: (bytes / 1048576).toFixed(1) };
+}
+
+(async () => {
+  console.log(DRY ? "=== DRY RUN (복사 없음) ===" : "=== MIGRATION ===");
+  const keys = await collectKeys();
+  for (const bucket of ["documents", "signed-documents"]) {
+    console.log(`\n[${bucket}] ${keys[bucket].size} keys`);
+    const r = await migrateBucket(bucket, keys[bucket]);
+    console.log(`  copied=${r.copied} skipped=${r.skipped} missing=${r.missing} failed=${r.failed} (${r.mb}MB)`);
+  }
+  console.log("\n=== 종료 ===");
+})();

--- a/scripts/migrate-storage-to-r2.mjs
+++ b/scripts/migrate-storage-to-r2.mjs
@@ -99,20 +99,38 @@ async function existsInR2(bucket, key) {
   try {
     await s3.send(new HeadObjectCommand({ Bucket: R2_BUCKET[bucket], Key: key }));
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    const status = e?.$metadata?.httpStatusCode;
+    if (status === 404 || e?.name === "NotFound" || e?.name === "NoSuchKey") return false;
+    // Surface auth/network/bucket errors instead of masking them as "missing".
+    throw e;
   }
+}
+
+// Lightweight source existence check (no download) for dry-run accuracy.
+async function existsInSupabase(bucket, key) {
+  const slash = key.lastIndexOf("/");
+  const folder = slash >= 0 ? key.slice(0, slash) : "";
+  const name = slash >= 0 ? key.slice(slash + 1) : key;
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .list(folder, { search: name, limit: 100 });
+  if (error) throw error;
+  return (data ?? []).some((f) => f.name === name);
 }
 
 async function migrateBucket(bucket, keys) {
   let copied = 0, skipped = 0, missing = 0, failed = 0, bytes = 0;
   for (const key of keys) {
     if (await existsInR2(bucket, key)) { skipped++; continue; }
-    if (DRY) { copied++; continue; } // report as "to copy" without downloading
+    if (DRY) {
+      if (await existsInSupabase(bucket, key)) copied++;
+      else { missing++; console.warn(`  ⚠️ source missing: ${bucket}/${key}`); }
+      continue;
+    }
     const { data, error } = await supabase.storage.from(bucket).download(key);
     if (error || !data) { missing++; console.warn(`  ⚠️ source missing: ${bucket}/${key}`); continue; }
     const buf = new Uint8Array(await data.arrayBuffer());
-    if (DRY) { copied++; bytes += buf.length; continue; }
     try {
       await s3.send(new PutObjectCommand({
         Bucket: R2_BUCKET[bucket],


### PR DESCRIPTION
## 개요 (Phase 1 / 무중단 이관 1차)
Supabase Storage 1GB 하드캡·egress 비용 해소를 위해 파일 저장을 **Cloudflare R2**로 이관합니다. 무중단·안전 롤백을 위해 **스트랭글러 패턴(dual-write + read-fallback)**으로 단계 배포합니다. 본 PR은 **1차 배포본**입니다.

## 롤아웃 단계
- **Phase 1 (이 PR)** — 추상화 레이어 + `dual` 모드. 배포 후 `STORAGE_PROVIDER=dual`:
  - write: R2(주) + Supabase(미러)
  - read: R2 우선 → 없으면 Supabase 폴백
  - → 신규 데이터는 양쪽 적재, 과거 데이터는 Supabase 폴백으로 정상 서빙
- **Phase 2 (운영 작업)** — 마이그레이션 스크립트로 과거 데이터를 R2로 백필 + DB `signed_*` 키 정규화
- **Phase 3 (별도 PR)** — `STORAGE_PROVIDER=r2` 전환 + Supabase 레거시 정리

## 변경 (커밋 단위)
1. `feat(storage)` — `lib/storage/` 추상화 레이어(types + Supabase/R2 구현 + 셀렉터), aws-sdk, `.env.example`
2. `refactor(storage)` — `document-actions` 이관 (signed_* 를 스토리지 키로 저장)
3. `refactor(storage)` — `template-actions` / `account-actions` 이관
4. `refactor(storage)` — 클라 미리보기: RLS 직접 download → 서버 presigned GET URL fetch
5. `chore(storage)` — Supabase→R2 마이그레이션 스크립트(멱등, DRY_RUN)
6. `feat(storage)` — **dual 프로바이더**(write both, read R2→Supabase)

## 안전성
- 기본값 `STORAGE_PROVIDER=supabase`에서 동작 동일 → 머지만으로는 무변화
- `dual`은 R2 write 실패 시에만 에러(주 저장소), Supabase 미러는 best-effort
- 전체 `tsc --noEmit` 통과 / 익명 서명자 업로드는 plain PUT이라 provider 무관

## 인프라 (완료)
- R2 버킷 2개 + 자격증명 R/W 검증
- R2 CORS: `localhost:3000`, `www.seuk-seuk.com`, `seuk-seuk.com`, `*.vercel.app` (GET/PUT/HEAD)

## 머지 후 (이 PR 배포 시)
1. Vercel에 R2 env 7개 등록 + **`STORAGE_PROVIDER=dual`**
2. 배포 → 신규 업로드/서명이 R2+Supabase 양쪽에 쌓이는지 확인
3. Phase 2 백필 진행

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 저장소 공급자 선택 설정이 추가되어 Cloudflare R2 및 혼합(듀얼) 저장 방식이 지원됩니다.
  * 문서/템플릿 미리보기와 다운로드가 서버 발급 기반 서명 URL로 전환되었습니다.
  * 서명 이미지→PDF 생성 및 서명 다운로드/업로드 흐름이 새 저장소 방식에 맞게 개선되었습니다.
* **Bug Fixes**
  * 문서 열람·다운로드 및 임시 파일 정리/삭제가 더 안정적으로 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->