### PR TITLE
fix: 이미지 문서 서명 제출 실패 수정 (R2 CORS 캐시 불일치) + 콘솔로그 정리

### DIFF
--- a/app/(billing)/checkout/credit/page.tsx
+++ b/app/(billing)/checkout/credit/page.tsx
@@ -33,7 +33,6 @@ export default function CreditCheckoutPage() {
         token: process.env.NEXT_PUBLIC_PADDLE_CLIENT_TOKEN,
         environment: process.env.NEXT_PUBLIC_PADDLE_ENV as Environments,
         eventCallback: (event) => {
-          console.log("Paddle event:", event);
           if (event.name === "checkout.error") {
             console.error("Paddle checkout error:", event);
           }
@@ -53,10 +52,6 @@ export default function CreditCheckoutPage() {
       }).then(async (paddleInstance) => {
         if (paddleInstance && PADDLE_CREDIT_PRICE_ID) {
           setPaddle(paddleInstance);
-          console.log("Opening Paddle checkout with:", {
-            priceId: PADDLE_CREDIT_PRICE_ID,
-            quantity,
-          });
           paddleInstance.Checkout.open({
             items: [{ priceId: PADDLE_CREDIT_PRICE_ID, quantity }],
             discountId: PADDLE_CREDIT_DISCOUNT_ID,

--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -840,6 +840,11 @@ export default function SignSingleDocument({
                 <img
                   src={documentSignedUrl || documentData.file_url}
                   alt="Document"
+                  // CORS mode must match the canvas-compositing Image() load:
+                  // without it Chrome caches the response sans ACAO header and
+                  // the later crossOrigin re-request fails (R2 unlike Supabase
+                  // only emits CORS headers when Origin is sent).
+                  crossOrigin="anonymous"
                   className="w-full h-auto object-contain block"
                   draggable="false"
                   style={{ userSelect: "none", WebkitUserSelect: "none" }}

--- a/app/actions/account-actions.ts
+++ b/app/actions/account-actions.ts
@@ -102,7 +102,6 @@ export async function deleteAccount(
       };
     }
 
-    console.log(`[Account Deletion] Starting deletion for user: ${user.id}`);
 
     // 3. Query user's documents to get file paths
     const { data: documents, error: docQueryError } = await supabase
@@ -172,7 +171,6 @@ export async function deleteAccount(
           console.error("[Account Deletion] Error deleting from documents storage:", storageError);
           // Continue with deletion
         } else {
-          console.log(`[Account Deletion] Deleted ${filePaths.length} files from documents storage`);
         }
       }
 
@@ -187,7 +185,6 @@ export async function deleteAccount(
           console.error("[Account Deletion] Error deleting from signed-documents storage:", signedStorageError);
           // Continue with deletion
         } else {
-          console.log(`[Account Deletion] Deleted ${signedFilePaths.length} files from signed-documents storage`);
         }
       }
 
@@ -202,7 +199,6 @@ export async function deleteAccount(
           console.error("[Account Deletion] Error deleting signatures:", signaturesError);
           // Continue with deletion
         } else {
-          console.log("[Account Deletion] Deleted signatures");
         }
       }
     }
@@ -217,7 +213,6 @@ export async function deleteAccount(
       console.error("[Account Deletion] Error deleting documents:", documentsError);
       // Continue with deletion
     } else {
-      console.log("[Account Deletion] Deleted documents");
     }
 
     // 6. Break circular reference: Set users.current_subscription_id to NULL (using service role)
@@ -230,7 +225,6 @@ export async function deleteAccount(
       console.error("[Account Deletion] Error updating users.current_subscription_id:", updateUserError);
       // Continue with deletion
     } else {
-      console.log("[Account Deletion] Cleared users.current_subscription_id");
     }
 
     // 7. Delete subscriptions (using service role to bypass RLS)
@@ -243,7 +237,6 @@ export async function deleteAccount(
       console.error("[Account Deletion] Error deleting subscriptions:", subscriptionsError);
       // Continue with deletion
     } else {
-      console.log("[Account Deletion] Deleted subscriptions");
     }
 
     // 8. Delete monthly_usage (using service role to bypass RLS)
@@ -256,7 +249,6 @@ export async function deleteAccount(
       console.error("[Account Deletion] Error deleting monthly_usage:", usageError);
       // Continue with deletion
     } else {
-      console.log("[Account Deletion] Deleted monthly_usage");
     }
 
     // 9. Delete customers record (using service role to bypass RLS)
@@ -269,7 +261,6 @@ export async function deleteAccount(
       console.error("[Account Deletion] Error deleting customers:", customersError);
       // Continue with deletion
     } else {
-      console.log("[Account Deletion] Deleted customers");
     }
 
     // 10. Delete users profile (using service role to bypass RLS)
@@ -282,7 +273,6 @@ export async function deleteAccount(
       console.error("[Account Deletion] Error deleting users profile:", usersError);
       // Continue with deletion
     } else {
-      console.log("[Account Deletion] Deleted users profile");
     }
 
     // 11. Delete auth.users account (using service role)
@@ -299,12 +289,10 @@ export async function deleteAccount(
       };
     }
 
-    console.log("[Account Deletion] Successfully deleted auth user");
 
     // 12. Sign out the user
     await supabase.auth.signOut();
 
-    console.log("[Account Deletion] Deletion completed successfully");
 
     // 13. Revalidate
     revalidatePath("/");

--- a/app/actions/credit-actions.ts
+++ b/app/actions/credit-actions.ts
@@ -199,11 +199,6 @@ export async function deductCredit(
     }
 
     // Only return success when data === true
-    console.log("Credit deduction successful", {
-      userId: user.id,
-      type,
-      documentId,
-    });
     return { success: true };
   } catch (error) {
     console.error("Deduct credit error:", error);
@@ -249,7 +244,6 @@ export async function addCredits(
 
     // Log if this was a duplicate (idempotent retry)
     if (result.error_message === "Already processed") {
-      console.log(`Idempotent webhook: ${paddleTransactionId} already processed`);
     }
 
     return { success: true };

--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -451,7 +451,6 @@ export async function createSignedDocumentUploadUrl(
     );
 
     if (existingFiles.length > 0) {
-      console.log(`[Upload] Cleaning up ${existingFiles.length} existing files for document ${documentId}`);
       await storage.remove("signed-documents", existingFiles);
     }
 
@@ -488,7 +487,6 @@ export async function generateSignedPdf(
   signedImagePath: string
 ) {
   const startTime = Date.now();
-  console.log(`[PDF] Starting PDF generation for ${documentId}`);
 
   try {
     const supabase = await createServerSupabase();
@@ -505,7 +503,6 @@ export async function generateSignedPdf(
       return { error: 'Document not found' };
     }
 
-    console.log(`[PDF] Document verified (${Date.now() - startTime}ms)`);
 
     // Restrict to the owner's expected key (storage RLS is not a backstop when
     // using service-role / R2). Prevents reading/deleting arbitrary keys.
@@ -525,9 +522,6 @@ export async function generateSignedPdf(
       return { error: 'Failed to download signed image' };
     }
 
-    console.log(
-      `[PDF] Image downloaded: ${imageType || 'unknown'}, ${Math.round(imageBytes.length / 1024)}KB (${Date.now() - startTime}ms)`
-    );
 
     // Generate PDF from signed image with A4 size optimization
     const { PDFDocument } = await import('pdf-lib');
@@ -582,7 +576,6 @@ export async function generateSignedPdf(
     const pdfBytes = await pdfDoc.save({
       useObjectStreams: true, // Enable compression
     });
-    console.log(`[PDF] PDF generated: ${Math.round(pdfBytes.length / 1024)}KB (${Date.now() - startTime}ms)`);
 
     const pdfBlob = new Blob([pdfBytes.buffer as ArrayBuffer], { type: 'application/pdf' });
     const pdfFilename = `signed_${documentId}.pdf`;
@@ -600,7 +593,6 @@ export async function generateSignedPdf(
       return { error: 'Failed to upload signed document PDF' };
     }
 
-    console.log(`[PDF] PDF uploaded successfully (${Date.now() - startTime}ms)`);
 
     // Store the storage key (private bucket; URLs are generated on read)
     const { error: updateError } = await supabase
@@ -621,13 +613,10 @@ export async function generateSignedPdf(
       // Non-critical: log but don't fail the operation
       console.warn(`[PDF] Failed to cleanup PNG file ${signedImagePath}:`, pngDeleteError);
     } else {
-      console.log(`[PDF] PNG cleanup successful: ${signedImagePath} (${Date.now() - startTime}ms)`);
     }
 
-    console.log(`[PDF] Database updated (${Date.now() - startTime}ms)`);
 
     const totalTime = Date.now() - startTime;
-    console.log(`[PDF] ✅ Complete! Total time: ${totalTime}ms`);
 
     return { success: true, signedPdfUrl: pdfPath };
   } catch (error) {
@@ -642,7 +631,6 @@ export async function generateSignedPdf(
  */
 export async function generateSignedPdfFromPdf(documentId: string) {
   const startTime = Date.now();
-  console.log(`[PDF-Sign] Starting PDF signing for ${documentId}`);
 
   try {
     const supabaseService = createServiceSupabase();
@@ -676,7 +664,6 @@ export async function generateSignedPdfFromPdf(documentId: string) {
       return { error: 'Failed to download original PDF' };
     }
 
-    console.log(`[PDF-Sign] Original PDF downloaded (${Date.now() - startTime}ms)`);
 
     // Get all signed signatures for this document
     const { data: signatures, error: sigError } = await supabaseService
@@ -695,13 +682,10 @@ export async function generateSignedPdfFromPdf(documentId: string) {
     const pdfDoc = await PDFDocument.load(pdfBytes);
     const pages = pdfDoc.getPages();
 
-    console.log(`[PDF-Sign] PDF loaded with ${pages.length} pages (${Date.now() - startTime}ms)`);
 
-    console.log(`[PDF-Sign] Found ${signatures.length} signed signatures`);
 
     // Embed each signature into the correct page
     for (const sig of signatures) {
-      console.log(`[PDF-Sign] Processing sig ${sig.id}: page=${sig.page_number}, coords=(${sig.x},${sig.y},${sig.width},${sig.height})`);
 
       if (!sig.signature_data || sig.x == null || sig.y == null || sig.width == null || sig.height == null) {
         console.warn(`[PDF-Sign] Skipping sig ${sig.id}: missing data or coordinates`);
@@ -731,7 +715,6 @@ export async function generateSignedPdfFromPdf(documentId: string) {
       // Flip Y axis: PDF y=0 is bottom, web y=0 is top
       const sigY = pageHeight - ((sy / 100) * pageHeight) - sigHeight;
 
-      console.log(`[PDF-Sign] Page ${pageIndex} size: ${pageWidth}x${pageHeight}, sig coords: (${sigX.toFixed(1)}, ${sigY.toFixed(1)}) ${sigWidth.toFixed(1)}x${sigHeight.toFixed(1)}`);
 
       try {
         // Extract base64 data from data URL
@@ -741,7 +724,6 @@ export async function generateSignedPdfFromPdf(documentId: string) {
           return { error: `Failed to process signature data for sig ${sig.id}` };
         }
 
-        console.log(`[PDF-Sign] Sig ${sig.id}: data length ${base64Data.length}`);
 
         const sigBytes = Uint8Array.from(atob(base64Data), c => c.charCodeAt(0));
 
@@ -776,7 +758,6 @@ export async function generateSignedPdfFromPdf(documentId: string) {
           height: drawHeight,
         });
 
-        console.log(`[PDF-Sign] Embedded sig ${sig.id} on page ${pageIndex} at (${sigX.toFixed(1)}, ${sigY.toFixed(1)}) size ${drawWidth.toFixed(1)}x${drawHeight.toFixed(1)}`);
       } catch (embedErr) {
         console.error(`[PDF-Sign] Failed to embed signature ${sig.id}:`, embedErr);
         return { error: `Failed to embed signature on page ${pageIndex}` };
@@ -785,7 +766,6 @@ export async function generateSignedPdfFromPdf(documentId: string) {
 
     // Save the signed PDF
     const signedPdfBytes = await pdfDoc.save();
-    console.log(`[PDF-Sign] Signed PDF generated: ${Math.round(signedPdfBytes.length / 1024)}KB (${Date.now() - startTime}ms)`);
 
     const pdfBlob = new Blob([signedPdfBytes.buffer as ArrayBuffer], { type: 'application/pdf' });
     const pdfFilename = `signed_${documentId}.pdf`;
@@ -817,7 +797,6 @@ export async function generateSignedPdfFromPdf(documentId: string) {
     }
 
     const totalTime = Date.now() - startTime;
-    console.log(`[PDF-Sign] ✅ Complete! Total time: ${totalTime}ms`);
 
     return { success: true, signedPdfUrl: pdfPath };
   } catch (error) {

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -31,11 +31,9 @@ export async function POST(request: NextRequest) {
     );
     const eventName = eventData?.eventType ?? "Unknown event";
 
-    console.log(`Received Paddle webhook: ${eventName}`);
 
     if (eventData) {
       await webhookProcessor.processEvent(eventData);
-      console.log(`Successfully processed webhook: ${eventName}`);
     }
 
     return Response.json({ status: 200, eventName });

--- a/components/document-upload.tsx
+++ b/components/document-upload.tsx
@@ -140,7 +140,6 @@ export default function DocumentUpload({ mode = "document" }: DocumentUploadProp
       try {
         const result = await canUploadPdf();
         if (!active) return;
-        console.log("[PDF Permission Check]", result);
         setCanUsePdf(result.canUpload);
       } catch (err) {
         if (!active) return;

--- a/lib/paddle/process-webhook.ts
+++ b/lib/paddle/process-webhook.ts
@@ -20,7 +20,6 @@ interface CreditPurchaseCustomData {
 
 export class ProcessWebhook {
   async processEvent(eventData: EventEntity) {
-    console.log(`Processing Paddle webhook event: ${eventData.eventType}`);
 
     switch (eventData.eventType) {
       case EventName.SubscriptionCreated:
@@ -36,7 +35,6 @@ export class ProcessWebhook {
         await this.handleTransactionCompleted(eventData);
         break;
       default:
-        console.log(`Unhandled event type: ${eventData.eventType}`);
     }
   }
 
@@ -52,11 +50,6 @@ export class ProcessWebhook {
         ? "canceled"
         : "updated";
 
-      console.log(
-        `[subscription.${eventType}] Processing subscription ${eventData.data.id} for customer ${
-          eventData.data.customerId
-        }`
-      );
 
       // customer_id로 customers 테이블에서 user_id 조회 (없을 수도 있음 - customer.created가 먼저 와야 함)
       const { data: customerData } = await supabase
@@ -65,13 +58,6 @@ export class ProcessWebhook {
         .eq("customer_id", eventData.data.customerId)
         .single();
 
-      console.log(
-        `[subscription] Customer ${
-          eventData.data.customerId
-        } exists: ${!!customerData}, user_id: ${
-          customerData?.user_id || "not linked yet"
-        }`
-      );
 
       // IMPORTANT: customer가 없어도 계속 진행
       // customer.created 이벤트가 나중에 와서 customer를 생성하고 subscription을 연결할 것임
@@ -97,12 +83,6 @@ export class ProcessWebhook {
       // 4. 기존 subscriptions 테이블에 Paddle 구독 정보 upsert
 
       // Log detailed subscription data for debugging
-      console.log('[subscription] Paddle data:', JSON.stringify({
-        status: eventData.data.status,
-        scheduled_change: eventData.data.scheduled_change,
-        next_billed_at: eventData.data.next_billed_at,
-        current_billing_period: eventData.data.currentBillingPeriod,
-      }, null, 2));
 
       // Calculate ends_at from scheduled_change or next_billed_at
       let endsAt: string | null = null;
@@ -111,23 +91,19 @@ export class ProcessWebhook {
       // Priority 1: If subscription has scheduled cancellation, use effective_at
       if (eventData.data.scheduled_change?.action === 'cancel') {
         endsAt = eventData.data.scheduled_change.effective_at || null;
-        console.log(`[subscription] Scheduled cancellation detected, ends_at: ${endsAt}`);
 
         // Check if subscription has already expired
         if (endsAt && new Date(endsAt) < new Date()) {
           finalStatus = 'expired';
-          console.log(`[subscription] Subscription already expired, changing status to 'expired'`);
         }
       }
       // Priority 2: Use next_billed_at for active recurring subscriptions
       else if (eventData.data.next_billed_at) {
         endsAt = eventData.data.next_billed_at;
-        console.log(`[subscription] Setting ends_at to next billing date: ${endsAt}`);
       }
       // Priority 3: Fallback to current billing period end date
       else if (eventData.data.currentBillingPeriod?.endsAt) {
         endsAt = eventData.data.currentBillingPeriod.endsAt;
-        console.log(`[subscription] Using current billing period end date: ${endsAt}`);
       }
 
       // If still no ends_at and status is canceled, log warning
@@ -139,7 +115,6 @@ export class ProcessWebhook {
 
       // user_id가 있으면 기존 subscription 레코드를 업데이트, 없으면 새로 생성
       if (customerData?.user_id) {
-        console.log(`[subscription] User ${customerData.user_id} exists, checking for existing subscription...`);
 
         // 이 user의 기존 subscription 찾기 (plan_id 포함)
         const { data: existingUserSub } = await supabase
@@ -150,7 +125,6 @@ export class ProcessWebhook {
 
         if (existingUserSub) {
           // 기존 subscription 업데이트 (Free → Pro 등)
-          console.log(`[subscription] Updating existing subscription ${existingUserSub.id} to ${planName}`);
 
           // Check if this is a plan upgrade by comparing old and new plan_id
           const isUpgrade = existingUserSub.plan_id !== planData.id;
@@ -169,14 +143,12 @@ export class ProcessWebhook {
               .eq("id", planData.id)
               .single();
 
-            console.log(`[subscription] Plan change detected: ${oldPlan?.name} → ${newPlan?.name}`);
 
             // Reset monthly usage if upgrading to a higher tier (higher limits)
             if (oldPlan && newPlan && 
                 (newPlan.monthly_document_limit > oldPlan.monthly_document_limit ||
                  newPlan.active_document_limit > oldPlan.active_document_limit)) {
               
-              console.log(`[subscription] Plan upgrade detected! Resetting monthly usage for user ${customerData.user_id}`);
 
               const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM format
               
@@ -192,7 +164,6 @@ export class ProcessWebhook {
               if (resetError) {
                 console.error("[subscription] Failed to reset monthly usage:", resetError);
               } else {
-                console.log(`[subscription] ✅ Successfully reset monthly usage for ${currentMonth}`);
               }
             }
           }
@@ -219,10 +190,8 @@ export class ProcessWebhook {
           }
 
           subscriptionId = updatedSub!.id;
-          console.log(`[subscription] Updated subscription to ${planName}: ${subscriptionId}`);
         } else {
           // user는 있지만 subscription이 없는 경우 (정상적이지 않은 상황)
-          console.log(`[subscription] User has no subscription, creating new one`);
 
           const { data: newSub, error: insertError } = await supabase
             .from("subscriptions")
@@ -246,11 +215,9 @@ export class ProcessWebhook {
           }
 
           subscriptionId = newSub!.id;
-          console.log(`[subscription] Created subscription: ${subscriptionId}`);
         }
       } else {
         // user_id가 없으면 일단 subscription만 생성 (transaction.completed에서 연결됨)
-        console.log(`[subscription] No user linked yet, creating unlinked subscription`);
 
         const { data: newSub, error: insertError } = await supabase
           .from("subscriptions")
@@ -274,7 +241,6 @@ export class ProcessWebhook {
         }
 
         subscriptionId = newSub!.id;
-        console.log(`[subscription] Created unlinked subscription: ${subscriptionId}`);
       }
 
       // 5. users.current_subscription_id 업데이트 (user_id가 있을 때만)
@@ -291,13 +257,7 @@ export class ProcessWebhook {
           );
         }
 
-        console.log(
-          `Updated user ${customerData.user_id} subscription to ${planName} (${finalStatus})`
-        );
       } else {
-        console.log(
-          `Created subscription ${subscriptionId} for ${planName} (${finalStatus}) - waiting for transaction.completed to link to user`
-        );
       }
     } catch (error) {
       console.error("Error processing subscription webhook:", error);
@@ -317,13 +277,6 @@ export class ProcessWebhook {
     const supabase = createServiceSupabase();
 
     try {
-      console.log(
-        `[customer.${
-          eventData.eventType.includes("created") ? "created" : "updated"
-        }] Processing customer ${eventData.data.id} with email ${
-          eventData.data.email
-        }`
-      );
 
       // 이메일로 사용자 찾기 (Supabase Auth Admin API 사용)
       const {
@@ -346,11 +299,6 @@ export class ProcessWebhook {
         throw error;
       }
 
-      console.log(
-        `[customer] Upserted customer: ${eventData.data.id} with email ${
-          eventData.data.email
-        }, user: ${user?.id || "not found"}`
-      );
 
       // user_id가 있으면, 이 customer의 subscription을 찾아서 user_id 연결 (보조적 역할)
       if (user?.id) {
@@ -362,9 +310,6 @@ export class ProcessWebhook {
           .is("user_id", null);
 
         if (subscriptions && subscriptions.length > 0) {
-          console.log(
-            `[customer] Found ${subscriptions.length} unlinked subscription(s) for customer ${eventData.data.id} - linking to user ${user.id}`
-          );
 
           for (const sub of subscriptions) {
             // subscription의 user_id 업데이트
@@ -392,9 +337,6 @@ export class ProcessWebhook {
                 .eq("id", user.id);
             }
 
-            console.log(
-              `[customer] Linked subscription ${sub.id} (${sub.paddle_subscription_id}) to user ${user.id}`
-            );
           }
         }
       }
@@ -418,7 +360,6 @@ export class ProcessWebhook {
       const customData = eventData.data.customData as CreditPurchaseCustomData | undefined;
 
       if (customData?.type === "credit") {
-        console.log("[transaction.completed] Credit purchase detected");
         await this.handleCreditPurchase(eventData, customData);
         return;
       }
@@ -426,27 +367,17 @@ export class ProcessWebhook {
       const customerId = eventData.data.customerId;
 
       if (!customerId) {
-        console.log("[transaction.completed] No customer_id in event");
         return;
       }
 
-      console.log(
-        `[transaction.completed] Processing for customer ${customerId}`
-      );
 
       // 1. Paddle API로 customer 정보 가져오기 (실제 이메일 포함)
       const paddle = getPaddleInstance();
       let customerEmail: string | null = null;
 
       try {
-        console.log(
-          `[transaction.completed] Fetching customer info from Paddle API...`
-        );
         const paddleCustomer = await paddle.customers.get(customerId);
         customerEmail = paddleCustomer.email;
-        console.log(
-          `[transaction.completed] Fetched customer email from Paddle: ${customerEmail}`
-        );
       } catch (apiError) {
         console.error(
           `[transaction.completed] Failed to fetch customer from Paddle API:`,
@@ -461,21 +392,12 @@ export class ProcessWebhook {
 
         if (dbCustomer?.email && !dbCustomer.email.includes("placeholder")) {
           customerEmail = dbCustomer.email;
-          console.log(
-            `[transaction.completed] Using email from database: ${customerEmail}`
-          );
         } else {
-          console.log(
-            `[transaction.completed] No valid email found, waiting for customer.created event`
-          );
           return;
         }
       }
 
       if (!customerEmail) {
-        console.log(
-          `[transaction.completed] No email available for customer ${customerId}`
-        );
         return;
       }
 
@@ -487,9 +409,6 @@ export class ProcessWebhook {
         .single();
 
       if (customerError || !customerData) {
-        console.log(
-          `[transaction.completed] Customer ${customerId} not in database, creating...`
-        );
 
         // customer 레코드 생성 (실제 이메일 사용)
         const { data: newCustomer, error: insertError } = await supabase
@@ -511,16 +430,10 @@ export class ProcessWebhook {
         }
 
         customerData = newCustomer;
-        console.log(
-          `[transaction.completed] Created customer ${customerId} with email ${customerEmail}`
-        );
       }
 
       // 3. user_id가 없으면 이메일로 user 찾아서 업데이트
       if (!customerData.user_id) {
-        console.log(
-          `[transaction.completed] Looking up user by email: ${customerEmail}`
-        );
 
         const {
           data: { users },
@@ -538,9 +451,6 @@ export class ProcessWebhook {
         const user = users?.find((u) => u.email === customerEmail);
 
         if (user) {
-          console.log(
-            `[transaction.completed] Found user ${user.id} for email ${customerEmail}`
-          );
 
           // 2a. customers 테이블에 user_id 업데이트
           const { error: customerUpdateError } = await supabase
@@ -556,9 +466,6 @@ export class ProcessWebhook {
             return;
           }
 
-          console.log(
-            `[transaction.completed] Updated customer ${customerId} with user_id ${user.id}`
-          );
 
           // 2b. 이 customer의 모든 unlinked subscriptions 찾아서 연결
           const { data: subscriptions, error: subsError } = await supabase
@@ -576,9 +483,6 @@ export class ProcessWebhook {
           }
 
           if (subscriptions && subscriptions.length > 0) {
-            console.log(
-              `[transaction.completed] Found ${subscriptions.length} unlinked subscription(s) for customer ${customerId}`
-            );
 
             for (const sub of subscriptions) {
               // subscription에 user_id 연결
@@ -613,30 +517,18 @@ export class ProcessWebhook {
                 }
               }
 
-              console.log(
-                `[transaction.completed] Successfully linked subscription ${sub.id} (${sub.paddle_subscription_id}) to user ${user.id}`
-              );
             }
 
-            console.log(
-              `[transaction.completed] ✅ Successfully linked all subscriptions for customer ${customerId} to user ${user.id}`
-            );
 
             // Check if this transaction includes a free trial and record usage
             const priceId = eventData.data.items[0]?.price?.id;
             if (priceId && this.isPriceWithTrial(priceId)) {
-              console.log(
-                `[transaction.completed] Free trial detected for priceId: ${priceId}`
-              );
               await this.recordTrialUsage(customerId);
             }
 
             // Send payment notification
             await this.sendPaymentNotification(subscriptions[0].id, supabase);
           } else {
-            console.log(
-              `[transaction.completed] No unlinked subscriptions found for customer ${customerId}`
-            );
           }
         } else {
           console.warn(
@@ -644,9 +536,6 @@ export class ProcessWebhook {
           );
         }
       } else if (customerData.user_id) {
-        console.log(
-          `[transaction.completed] Customer ${customerId} already linked to user ${customerData.user_id} - checking for unlinked subscriptions`
-        );
 
         // customer는 이미 linked되어 있지만 subscription이 아직 linked 안 되어있을 수 있음
         const { data: subscriptions } = await supabase
@@ -656,9 +545,6 @@ export class ProcessWebhook {
           .is("user_id", null);
 
         if (subscriptions && subscriptions.length > 0) {
-          console.log(
-            `[transaction.completed] Found ${subscriptions.length} unlinked subscription(s) - linking now`
-          );
 
           for (const sub of subscriptions) {
             await supabase
@@ -676,9 +562,6 @@ export class ProcessWebhook {
                 .eq("id", customerData.user_id);
             }
 
-            console.log(
-              `[transaction.completed] Linked subscription ${sub.id} to existing user ${customerData.user_id}`
-            );
           }
 
           // Send payment notification for the first active subscription
@@ -686,18 +569,12 @@ export class ProcessWebhook {
             await this.sendPaymentNotification(subscriptions[0].id, supabase);
           }
         } else {
-          console.log(
-            `[transaction.completed] No unlinked subscriptions found - subscription already linked by subscription.created event`
-          );
         }
 
         // IMPORTANT: Check for free trial REGARDLESS of whether subscription was just linked or already linked
         // This handles the case where subscription.created came before transaction.completed
         const priceId = eventData.data.items[0]?.price?.id;
         if (priceId && this.isPriceWithTrial(priceId)) {
-          console.log(
-            `[transaction.completed] Free trial detected for priceId: ${priceId}`
-          );
           await this.recordTrialUsage(customerId);
         }
       }
@@ -770,9 +647,6 @@ export class ProcessWebhook {
           error
         );
       } else {
-        console.log(
-          `[trial-tracking] ✅ Recorded trial usage for customer: ${customerId}`
-        );
       }
     } catch (error) {
       console.error(
@@ -832,13 +706,11 @@ export class ProcessWebhook {
       
       const notificationEndpoint = process.env.NOTIFICATION_ENDPOINT;
       if (!notificationEndpoint) {
-        console.log("[notification] NOTIFICATION_ENDPOINT not configured, skipping notification");
         return;
       }
 
       const notificationBody = `플랜: ${planName}\n상태: ${subscription.status}`;
 
-      console.log(`[notification] Sending payment notification for plan: ${planName}`);
 
       const response = await fetch(notificationEndpoint, {
         method: "POST",
@@ -854,7 +726,6 @@ export class ProcessWebhook {
       if (!response.ok) {
         console.error(`[notification] Failed to send notification: ${response.status} ${response.statusText}`);
       } else {
-        console.log(`[notification] ✅ Successfully sent payment notification for ${planName}`);
       }
     } catch (notificationError) {
       console.error("[notification] Error sending payment notification:", notificationError);
@@ -887,9 +758,6 @@ export class ProcessWebhook {
         return;
       }
 
-      console.log(
-        `[credit-purchase] Processing credit purchase: ${quantity} credits for customer ${customerId}`
-      );
 
       // Check for duplicate transaction
       const { data: existingTransaction } = await supabase
@@ -899,9 +767,6 @@ export class ProcessWebhook {
         .single();
 
       if (existingTransaction) {
-        console.log(
-          `[credit-purchase] Transaction ${transactionId} already processed, skipping`
-        );
         return;
       }
 
@@ -917,10 +782,8 @@ export class ProcessWebhook {
 
       if (customerData?.user_id) {
         userId = customerData.user_id;
-        console.log(`[credit-purchase] Found user ${userId} from existing customer record`);
       } else {
         // 1b. Customer doesn't exist or not linked - fetch from Paddle API and find user by email
-        console.log(`[credit-purchase] Customer not found in DB, fetching from Paddle API...`);
 
         const paddle = getPaddleInstance();
         let customerEmail: string | null = null;
@@ -928,7 +791,6 @@ export class ProcessWebhook {
         try {
           const paddleCustomer = await paddle.customers.get(customerId);
           customerEmail = paddleCustomer.email;
-          console.log(`[credit-purchase] Fetched customer email from Paddle: ${customerEmail}`);
         } catch (apiError) {
           console.error(`[credit-purchase] Failed to fetch customer from Paddle API:`, apiError);
           return;
@@ -960,7 +822,6 @@ export class ProcessWebhook {
         }
 
         userId = user.id;
-        console.log(`[credit-purchase] Found user ${userId} by email ${customerEmail}`);
 
         // Create or update customer record
         await supabase
@@ -971,7 +832,6 @@ export class ProcessWebhook {
             user_id: userId,
           });
 
-        console.log(`[credit-purchase] Created/updated customer record for ${customerId}`);
       }
 
       if (!userId) {
@@ -1022,10 +882,6 @@ export class ProcessWebhook {
         throw balanceError;
       }
 
-      console.log(
-        `[credit-purchase] ✅ Successfully added ${quantity} credits for user ${userId}. ` +
-        `New balance: create=${newCreateCredits}, publish=${newPublishCredits}`
-      );
 
       // 4. Send notification (optional)
       await this.sendCreditPurchaseNotification(quantity, userId);
@@ -1042,13 +898,11 @@ export class ProcessWebhook {
     try {
       const notificationEndpoint = process.env.NOTIFICATION_ENDPOINT;
       if (!notificationEndpoint) {
-        console.log("[notification] NOTIFICATION_ENDPOINT not configured, skipping notification");
         return;
       }
 
       const notificationBody = `수량: ${quantity}개\n사용자 ID: ${userId.substring(0, 8)}...`;
 
-      console.log(`[notification] Sending credit purchase notification: ${quantity} credits`);
 
       const response = await fetch(notificationEndpoint, {
         method: "POST",
@@ -1064,7 +918,6 @@ export class ProcessWebhook {
       if (!response.ok) {
         console.error(`[notification] Failed to send notification: ${response.status} ${response.statusText}`);
       } else {
-        console.log(`[notification] ✅ Successfully sent credit purchase notification`);
       }
     } catch (notificationError) {
       console.error("[notification] Error sending credit notification:", notificationError);

--- a/lib/paddle/validate-price-id.ts
+++ b/lib/paddle/validate-price-id.ts
@@ -50,7 +50,6 @@ export async function validateAndGetPriceId(
 
   // 5. customer 레코드가 없으면 첫 구매 → 무료체험 허용
   if (!customer) {
-    console.log(`No customer record for ${userEmail}, allowing free trial`);
     return requestedPriceId;
   }
 
@@ -60,9 +59,6 @@ export async function validateAndGetPriceId(
       cycle === "month" ? tier.priceId.monthNoTrial : tier.priceId.yearNoTrial;
 
     if (noTrialPriceId) {
-      console.log(
-        `Price validation: ${userEmail} requested ${requestedPriceId}, returned ${noTrialPriceId} (trial already used)`
-      );
       return noTrialPriceId;
     } else {
       console.warn(
@@ -73,7 +69,6 @@ export async function validateAndGetPriceId(
   }
 
   // 7. 이력 없으면 원래 priceId 반환 (무료체험 제공)
-  console.log(`Price validation: ${userEmail} eligible for free trial`);
   return requestedPriceId;
 }
 


### PR DESCRIPTION
## 1. 이미지 문서 서명 제출 실패 (프로덕션 버그)

### 증상
R2 dual 배포 후 이미지 문서 서명 제출 시 "이미지를 불러올 수 없습니다" 에러로 실패 (PDF 문서는 정상). 콘솔: presigned GET에 `No 'Access-Control-Allow-Origin' header` CORS 차단.

### 원인 (캐시 모드 불일치)
1. 미리보기 `<img src={presignedUrl}>`가 **CORS 모드 없이** 로드 → Chrome이 ACAO 헤더 없는 응답을 HTTP 캐시에 저장
2. 제출 시 canvas 합성용 `new Image(); crossOrigin="anonymous"`가 **같은 presigned URL**을 요청 → 캐시 히트 → ACAO 없음 → CORS 차단
3. **Supabase는 모든 응답에 `ACAO: *`를 무조건 부여**해 기존엔 문제가 없었으나, **R2는 Origin 헤더가 있을 때만 CORS 헤더를 반환** → R2 전환으로 표면화된 회귀

R2 CORS 설정 자체는 정상임을 재현 테스트로 확인 (동일 객체·동일 오리진에서 vhost/path 스타일 모두 ACAO 정상 반환).

### 수정
미리보기 `<img>`에 `crossOrigin="anonymous"` 지정 → 첫 로드부터 CORS 모드로 캐시되어 재요청과 일치.

## 2. 디버그 console.log 일괄 제거 (104건)
진행상황·디버그성 `console.log` 전부 제거, 오류 진단용 `console.error/warn`(308건)은 유지. 순수 삭제 199줄, 신규 타입 에러 없음 (오히려 로그 내 paddle 타입 에러 2건 감소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)