### PR TITLE
fix(publications): allow deleting unfinished publications

### DIFF
--- a/app/actions/publication-actions.ts
+++ b/app/actions/publication-actions.ts
@@ -312,6 +312,7 @@ export async function getPublicationByShortUrl(
         documents(*, signatures(*))
       `)
       .eq("short_url", shortUrl)
+      .eq("is_deleted", false)
       .single();
 
     if (pubError || !publication) {
@@ -458,7 +459,12 @@ export async function checkAndCompletePublication(
 }
 
 /**
- * Delete a publication and unlink documents
+ * Delete a publication and unlink documents.
+ *
+ * Completed publications are archived with their completed documents. Any
+ * non-completed publication can be deleted on request: its documents are
+ * detached, reset to draft, and any in-progress signature data is cleared so
+ * the owner can publish them again cleanly.
  */
 export async function deletePublication(
   publicationId: string
@@ -471,7 +477,7 @@ export async function deletePublication(
       return { error: "User not authenticated" };
     }
 
-    // Verify publication belongs to user and get documents with signatures
+    // Verify publication belongs to user and get related documents/signatures.
     const { data: publication, error: verifyError } = await supabase
       .from("publications")
       .select(`
@@ -486,38 +492,42 @@ export async function deletePublication(
       `)
       .eq("id", publicationId)
       .eq("user_id", user.id)
+      .eq("is_deleted", false)
       .single();
 
     if (verifyError || !publication) {
       return { error: "Publication not found or not owned by user" };
     }
 
-    // Handle completed publications with soft delete
+    const deletedAt = new Date().toISOString();
+    const documents = (publication.documents as any[]) || [];
+    const documentIds = documents.map((doc) => doc.id).filter(Boolean);
+
+    // Completed publications keep their final state but are hidden from lists.
     if (publication.status === "completed") {
-      // Soft delete publication
       const { error: softDeletePubError } = await supabase
         .from("publications")
         .update({
           is_deleted: true,
-          deleted_at: new Date().toISOString()
+          deleted_at: deletedAt,
         })
-        .eq("id", publicationId);
+        .eq("id", publicationId)
+        .eq("user_id", user.id);
 
       if (softDeletePubError) {
         console.error("Publication soft delete error:", softDeletePubError);
         return { error: "Failed to delete publication" };
       }
 
-      // Soft delete all associated documents (keep status as completed)
-      const documentIds = (publication.documents as any[])?.map(doc => doc.id) || [];
       if (documentIds.length > 0) {
         const { error: softDeleteDocsError } = await supabase
           .from("documents")
           .update({
             is_deleted: true,
-            deleted_at: new Date().toISOString()
+            deleted_at: deletedAt,
           })
-          .in("id", documentIds);
+          .in("id", documentIds)
+          .eq("user_id", user.id);
 
         if (softDeleteDocsError) {
           console.error("Documents soft delete error:", softDeleteDocsError);
@@ -531,76 +541,51 @@ export async function deletePublication(
       return { success: true };
     }
 
-    // Handle active publications
-    if (publication.status === "active") {
-      // Check if any document has signatures
-      const documents = (publication.documents as any[]) || [];
-      const hasSignatures = documents.some(doc =>
-        doc.signatures && doc.signatures.length > 0
-      );
+    // Non-completed publications are intentionally deletable even when some
+    // signature fields were already filled. Reset those fields so republishing
+    // starts from the original signature areas, not stale signer data.
+    if (documentIds.length > 0) {
+      const { error: resetSignaturesError } = await supabase
+        .from("signatures")
+        .update({
+          signature_data: null,
+          status: "pending",
+          signer_name: null,
+          signed_at: null,
+        })
+        .in("document_id", documentIds);
 
-      if (hasSignatures) {
-        return { error: "Cannot delete publication with signed documents" };
+      if (resetSignaturesError) {
+        console.error("Signature reset error:", resetSignaturesError);
+        return { error: "Failed to reset signatures" };
       }
 
-      // No signatures - can delete and revert documents to draft
-      // Unlink documents (set publication_id to null and status to draft)
       const { error: unlinkError } = await supabase
         .from("documents")
         .update({
           publication_id: null,
-          status: "draft"
+          status: "draft",
+          signed_file_url: null,
+          signed_pdf_url: null,
         })
-        .eq("publication_id", publicationId);
+        .in("id", documentIds)
+        .eq("user_id", user.id);
 
       if (unlinkError) {
         console.error("Document unlinking error:", unlinkError);
         return { error: "Failed to unlink documents" };
       }
-
-      // Note: monthly_usage.published_completed_count is automatically updated by
-      // the database trigger (trigger_document_status_change) when document status changes
-      // No need to manually decrement here
-
-      // Delete publication
-      const { error: deleteError } = await supabase
-        .from("publications")
-        .delete()
-        .eq("id", publicationId);
-
-      if (deleteError) {
-        console.error("Publication deletion error:", deleteError);
-        return { error: "Failed to delete publication" };
-      }
-
-      revalidatePath("/dashboard");
-      revalidatePath("/publish");
-
-      return { success: true };
     }
 
-    // Handle expired publications (treat like active)
-    if (publication.status === "expired") {
-      // Check if any document has signatures
-      const documents = (publication.documents as any[]) || [];
-      const hasSignatures = documents.some(doc =>
-        doc.signatures && doc.signatures.length > 0
-      );
+    const { error: deleteError } = await supabase
+      .from("publications")
+      .delete()
+      .eq("id", publicationId)
+      .eq("user_id", user.id);
 
-      if (hasSignatures) {
-        return { error: "Cannot delete publication with signed documents" };
-      }
-
-      // No signatures - can delete
-      const { error: deleteError } = await supabase
-        .from("publications")
-        .delete()
-        .eq("id", publicationId);
-
-      if (deleteError) {
-        console.error("Publication deletion error:", deleteError);
-        return { error: "Failed to delete publication" };
-      }
+    if (deleteError) {
+      console.error("Publication deletion error:", deleteError);
+      return { error: "Failed to delete publication" };
     }
 
     revalidatePath("/dashboard");

--- a/components/dashboard/publication-card.tsx
+++ b/components/dashboard/publication-card.tsx
@@ -42,8 +42,8 @@ export function PublicationCard({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
 
-  // Check if publication can be deleted (only completed)
-  const canDelete = publication.status === "completed";
+  // Publications can always be selected/deleted; non-completed ones are reset to draft.
+  const canDelete = true;
 
   const getStatusBadge = (status: ClientPublication["status"]) => {
     const statusMap: Record<string, { label: string; variant: "default" | "success" | "secondary" }> = {
@@ -282,7 +282,9 @@ export function PublicationCard({
             <AlertDialogDescription>
               {t("dashboard.publications.delete.description", { name: publication.name })}
               <br />
-              {t("dashboard.publications.delete.warning")}
+              {publication.status === "completed"
+                ? t("dashboard.publications.delete.warningCompleted")
+                : t("dashboard.publications.delete.warningReset")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/components/dashboard/publications-list.tsx
+++ b/components/dashboard/publications-list.tsx
@@ -81,13 +81,9 @@ export function PublicationsList({ statusFilter = "all" }: PublicationsListProps
     });
   };
 
-  // Select all deletable publications
+  // Select all publications. Non-completed publications are reset to draft on delete.
   const handleSelectAll = () => {
-    const deletablePublicationIds = publications
-      .filter((pub) => pub.status === "completed")
-      .map((pub) => pub.id);
-
-    setSelectedPublicationIds(new Set(deletablePublicationIds));
+    setSelectedPublicationIds(new Set(publications.map((pub) => pub.id)));
   };
 
   // Deselect all publications

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -427,14 +427,16 @@ const translations: Record<Language, Record<string, string>> = {
     "dashboard.publications.card.documentCount": "개 문서",
     "dashboard.publications.card.copied": "복사됨",
     "dashboard.publications.card.copyLink": "링크",
-    "dashboard.publications.card.cannotDelete": "완료된 발행은 삭제할 수 없습니다",
+    "dashboard.publications.card.cannotDelete": "발행을 삭제할 수 있습니다",
     "dashboard.publications.delete.title": "발행 삭제",
     "dashboard.publications.delete.description": "\"{name}\" 발행을 삭제하시겠습니까?",
     "dashboard.publications.delete.warning": "이 발행에 포함된 모든 문서는 초안 상태로 돌아갑니다.",
+    "dashboard.publications.delete.warningReset": "이 발행은 삭제되고 포함된 문서는 초안으로 돌아가며, 진행 중인 서명 데이터는 초기화됩니다.",
+    "dashboard.publications.delete.warningCompleted": "완료된 발행과 포함 문서는 보관 처리되어 목록에서 숨겨집니다.",
     "dashboard.publications.delete.cancel": "취소",
     "dashboard.publications.delete.confirm": "삭제",
     "dashboard.publications.delete.deleting": "삭제 중...",
-    "dashboard.publications.bulkDelete.cannotDelete": "완료되지 않은 발행은 삭제할 수 없습니다",
+    "dashboard.publications.bulkDelete.cannotDelete": "발행을 삭제할 수 있습니다",
     "dashboard.publications.bulkDelete.successMessage": "{{count}}개의 발행이 삭제되었습니다",
     "dashboard.publications.bulkDelete.errorMessage": "{{count}}개의 발행 삭제 실패: {{details}}",
     "dashboard.bulkDelete.selected": "{{count}}개 선택됨",
@@ -1618,14 +1620,16 @@ const translations: Record<Language, Record<string, string>> = {
     "dashboard.publications.card.documentCount": " documents",
     "dashboard.publications.card.copied": "Copied",
     "dashboard.publications.card.copyLink": "Link",
-    "dashboard.publications.card.cannotDelete": "Cannot delete completed publications",
+    "dashboard.publications.card.cannotDelete": "Publication can be deleted",
     "dashboard.publications.delete.title": "Delete Publication",
     "dashboard.publications.delete.description": "Are you sure you want to delete \"{name}\"?",
     "dashboard.publications.delete.warning": "All documents in this publication will return to draft status.",
+    "dashboard.publications.delete.warningReset": "This publication will be deleted, included documents will return to draft, and in-progress signature data will be reset.",
+    "dashboard.publications.delete.warningCompleted": "The completed publication and included documents will be archived and hidden from the list.",
     "dashboard.publications.delete.cancel": "Cancel",
     "dashboard.publications.delete.confirm": "Delete",
     "dashboard.publications.delete.deleting": "Deleting...",
-    "dashboard.publications.bulkDelete.cannotDelete": "Cannot delete non-completed publications",
+    "dashboard.publications.bulkDelete.cannotDelete": "Publication can be deleted",
     "dashboard.publications.bulkDelete.successMessage": "{{count}} publication(s) deleted successfully",
     "dashboard.publications.bulkDelete.errorMessage": "Failed to delete {{count}} publication(s): {{details}}",
     "dashboard.bulkDelete.selected": "{{count}} selected",
@@ -2496,11 +2500,13 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
       }
     }
 
-    // Replace parameters in the translation string (supports {{param}} format)
+    // Replace parameters in the translation string. Existing copy uses both
+    // {{param}} and {param}, so support both formats in a single pass.
     if (actualParams) {
       Object.keys(actualParams).forEach((param) => {
+        const escapedParam = param.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         translation = translation?.replace(
-          new RegExp(`\\{\\{${param}\\}\\}`, "g"),
+          new RegExp(`\\{\\{${escapedParam}\\}\\}|\\{${escapedParam}\\}`, "g"),
           String(actualParams![param])
         ) ?? '';
       });


### PR DESCRIPTION
## Summary
- Fix publication delete modal name interpolation for `{name}` / `{{name}}` placeholders
- Allow active/expired publications to be deleted by resetting linked documents back to draft
- Clear in-progress signature data so documents can be republished cleanly
- Keep completed publication deletion as archive/soft-delete behavior

## Validation
- `pnpm test`
- `RESEND_API_KEY=re_dummy pnpm build`

## Notes
- Build requires `RESEND_API_KEY`; used a dummy value for static build validation.
- Existing lint script still prompts for ESLint configuration and was not used for this PR.