### PR TITLE
fix(security): documents/signatures anon 전체 개방 RLS 정책 잠금

### DIFF
--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -237,6 +237,91 @@ export async function getDocumentByShortUrl(shortUrl: string): Promise<{
   }
 }
 
+type ServiceClient = ReturnType<typeof createServiceSupabase>;
+
+type SignableDocumentRow = {
+  id: string;
+  status: string;
+  publication_id: string | null;
+  user_id: string | null;
+  filename: string;
+  file_url: string;
+  file_type: string | null;
+  page_count: number | null;
+};
+
+type SignablePublicationRow = {
+  id: string;
+  short_url: string;
+  status: string;
+  expires_at: string | null;
+};
+
+/**
+ * Authorization gate for anonymous signer actions.
+ *
+ * Loads a document (and its publication) with the service-role client and
+ * validates that the document is currently signable: it must belong to a
+ * publication whose status is `active` and whose `expires_at` is null or in the
+ * future. The public RLS policies that used to let the anon key read/write
+ * `documents` and `signatures` are being removed (see
+ * db/rls-anon-lockdown-migration.sql), so every signer action must funnel its
+ * documents/signatures access through the returned service client after passing
+ * this gate — the client-provided `documentId` is otherwise unauthenticated.
+ *
+ * On a validation failure `error` is set. `document`/`service` are still
+ * returned whenever the document row exists so idempotent callers (e.g.
+ * markDocumentCompleted) can inspect the document status before treating the
+ * error as fatal.
+ */
+async function getSignableDocument(documentId: string): Promise<{
+  document?: SignableDocumentRow;
+  publication?: SignablePublicationRow;
+  service?: ServiceClient;
+  error?: string;
+}> {
+  const service = createServiceSupabase();
+
+  const { data: document, error: docError } = await service
+    .from("documents")
+    .select(
+      "id, status, publication_id, user_id, filename, file_url, file_type, page_count"
+    )
+    .eq("id", documentId)
+    .single();
+
+  if (docError || !document) {
+    return { error: "Document not found" };
+  }
+
+  if (!document.publication_id) {
+    return { error: "Document not found" };
+  }
+
+  const { data: publication, error: pubError } = await service
+    .from("publications")
+    .select("id, short_url, status, expires_at")
+    .eq("id", document.publication_id)
+    .single();
+
+  if (pubError || !publication) {
+    return { document, service, error: "Document not found" };
+  }
+
+  if (publication.status !== "active") {
+    return { document, service, error: "서명 기간이 만료되었습니다." };
+  }
+
+  if (
+    publication.expires_at &&
+    new Date(publication.expires_at) < new Date()
+  ) {
+    return { document, service, error: "서명 기간이 만료되었습니다." };
+  }
+
+  return { document, publication, service };
+}
+
 /**
  * Save a signature for a specific signature area
  */
@@ -246,17 +331,20 @@ export async function saveSignature(
   signatureData: string
 ) {
   try {
-    const supabase = await createServerSupabase();
+    // Validate signer access and switch to the service client (anon RLS removed)
+    const gate = await getSignableDocument(documentId);
+    if (gate.error || !gate.document || !gate.service) {
+      return { error: gate.error ?? "Document not found" };
+    }
+    const { document, publication, service } = gate;
 
-    // Get document to find publication_id for revalidation
-    const { data: document } = await supabase
-      .from("documents")
-      .select("publication_id")
-      .eq("id", documentId)
-      .single();
+    // Cannot sign a document that is already completed
+    if (document.status === "completed") {
+      return { error: "이미 제출된 문서입니다." };
+    }
 
     // Update signature with data, status, and signed_at
-    const { error: updateError } = await supabase
+    const { error: updateError } = await service
       .from("signatures")
       .update({
         signature_data: signatureData,
@@ -273,17 +361,8 @@ export async function saveSignature(
 
     // Revalidate relevant pages to show updated signature count
     revalidatePath(`/document/${documentId}`);
-    if (document?.publication_id) {
-      // Get publication short_url for revalidation
-      const { data: publication } = await supabase
-        .from("publications")
-        .select("short_url")
-        .eq("id", document.publication_id)
-        .single();
-
-      if (publication?.short_url) {
-        revalidatePath(`/publication/${publication.short_url}`);
-      }
+    if (publication?.short_url) {
+      revalidatePath(`/publication/${publication.short_url}`);
     }
 
     return { success: true };
@@ -298,26 +377,23 @@ export async function saveSignature(
  */
 export async function markDocumentCompleted(documentId: string) {
   try {
-    const supabase = await createServerSupabase();
+    const gate = await getSignableDocument(documentId);
 
-    // First check if document exists and is in the right state
-    const { data: document, error: docError } = await supabase
-      .from("documents")
-      .select("id, status, filename, publication_id")
-      .eq("id", documentId)
-      .single();
-
-    if (docError || !document) {
-      console.error("❌ Document not found:", docError);
-      return { error: "Document not found" };
-    }
-
-    if (document.status === "completed") {
+    // Idempotent: an already-completed document is a success regardless of the
+    // publication's current (possibly already-completed) state.
+    if (gate.document?.status === "completed") {
       return { success: true };
     }
 
+    if (gate.error || !gate.document || !gate.service) {
+      console.error("❌ Document not found:", gate.error);
+      return { error: gate.error ?? "Document not found" };
+    }
+
+    const { document, publication, service } = gate;
+
     // Update document status to completed
-    const { error } = await supabase
+    const { error } = await service
       .from("documents")
       .update({ status: "completed" })
       .eq("id", documentId);
@@ -340,13 +416,6 @@ export async function markDocumentCompleted(documentId: string) {
 
     // Check if document is part of a publication and auto-complete publication if all documents are done
     if (document.publication_id) {
-      // Get publication short_url for revalidation
-      const { data: publication } = await supabase
-        .from("publications")
-        .select("short_url")
-        .eq("id", document.publication_id)
-        .single();
-
       if (publication?.short_url) {
         revalidatePath(`/publication/${publication.short_url}`);
       }
@@ -418,21 +487,13 @@ export async function createSignedDocumentUploadUrl(
   error?: string;
 }> {
   try {
-    // Use service role to bypass RLS for presigned URL generation
-    const supabaseService = createServiceSupabase();
-    const supabase = await createServerSupabase();
-
-    // Get document to verify existence and get user_id
-    const { data: document, error: docError } = await supabase
-      .from('documents')
-      .select('id, user_id, status')
-      .eq('id', documentId)
-      .single();
-
-    if (docError || !document) {
-      console.error('[Upload] Document not found:', docError);
-      return { error: 'Document not found' };
+    // Validate signer access and use the service client (anon RLS removed)
+    const gate = await getSignableDocument(documentId);
+    if (gate.error || !gate.document) {
+      console.error('[Upload] Document not signable:', gate.error);
+      return { error: gate.error ?? 'Document not found' };
     }
+    const { document } = gate;
 
     if (document.status === 'completed') {
       return { error: 'Document already completed' };
@@ -489,19 +550,13 @@ export async function generateSignedPdf(
   const startTime = Date.now();
 
   try {
-    const supabase = await createServerSupabase();
-
-    // Get document to verify existence and get user_id
-    const { data: document, error: docError } = await supabase
-      .from('documents')
-      .select('id, user_id')
-      .eq('id', documentId)
-      .single();
-
-    if (docError || !document) {
-      console.error('[PDF] Document not found:', docError);
-      return { error: 'Document not found' };
+    // Validate signer access and use the service client (anon RLS removed)
+    const gate = await getSignableDocument(documentId);
+    if (gate.error || !gate.document || !gate.service) {
+      console.error('[PDF] Document not signable:', gate.error);
+      return { error: gate.error ?? 'Document not found' };
     }
+    const { document, service } = gate;
 
 
     // Restrict to the owner's expected key (storage RLS is not a backstop when
@@ -595,7 +650,7 @@ export async function generateSignedPdf(
 
 
     // Store the storage key (private bucket; URLs are generated on read)
-    const { error: updateError } = await supabase
+    const { error: updateError } = await service
       .from('documents')
       .update({ signed_file_url: pdfPath, signed_pdf_url: pdfPath })
       .eq('id', documentId);
@@ -633,20 +688,13 @@ export async function generateSignedPdfFromPdf(documentId: string) {
   const startTime = Date.now();
 
   try {
-    const supabaseService = createServiceSupabase();
-    const supabase = await createServerSupabase();
-
-    // Get document info
-    const { data: document, error: docError } = await supabase
-      .from('documents')
-      .select('id, user_id, file_url, file_type, page_count')
-      .eq('id', documentId)
-      .single();
-
-    if (docError || !document) {
-      console.error('[PDF-Sign] Document not found:', docError);
-      return { error: 'Document not found' };
+    // Validate signer access and use the service client (anon RLS removed)
+    const gate = await getSignableDocument(documentId);
+    if (gate.error || !gate.document || !gate.service) {
+      console.error('[PDF-Sign] Document not signable:', gate.error);
+      return { error: gate.error ?? 'Document not found' };
     }
+    const { document, service } = gate;
 
     if (document.file_type !== 'pdf') {
       return { error: 'Document is not a PDF type' };
@@ -666,7 +714,7 @@ export async function generateSignedPdfFromPdf(documentId: string) {
 
 
     // Get all signed signatures for this document
-    const { data: signatures, error: sigError } = await supabaseService
+    const { data: signatures, error: sigError } = await service
       .from('signatures')
       .select('*')
       .eq('document_id', documentId)
@@ -785,7 +833,7 @@ export async function generateSignedPdfFromPdf(documentId: string) {
     }
 
     // Store the storage key (private bucket; URLs are generated on read)
-    const { error: updateError } = await supabase
+    const { error: updateError } = await service
       .from('documents')
       .update({ signed_file_url: pdfPath, signed_pdf_url: pdfPath })
       .eq('id', documentId);
@@ -889,18 +937,12 @@ export async function getDocumentFileSignedUrl(
   error?: string;
 }> {
   try {
-    const supabase = await createServerSupabase();
-
-    // Get document
-    const { data: document, error: docError } = await supabase
-      .from("documents")
-      .select("id, file_url, status")
-      .eq("id", documentId)
-      .single();
-
-    if (docError || !document) {
-      return { signedUrl: null, error: "Document not found" };
+    // Validate signer access and use the service client (anon RLS removed)
+    const gate = await getSignableDocument(documentId);
+    if (gate.error || !gate.document) {
+      return { signedUrl: null, error: gate.error ?? "Document not found" };
     }
+    const { document } = gate;
 
     // Check completion
     if (document.status === "completed") {

--- a/app/actions/publication-actions.ts
+++ b/app/actions/publication-actions.ts
@@ -403,7 +403,9 @@ export async function checkAndCompletePublication(
   publicationId: string
 ): Promise<{ success?: boolean; isCompleted?: boolean; error?: string }> {
   try {
-    const supabase = await createServerSupabase();
+    // Service role: invoked from the anonymous signer completion path, and its
+    // logic is scoped to the publicationId (existence + all-docs-completed).
+    const supabase = createServiceSupabase();
 
     // Get publication info with short_url
     const { data: publication, error: pubError } = await supabase

--- a/db/rls-anon-lockdown-migration.sql
+++ b/db/rls-anon-lockdown-migration.sql
@@ -1,0 +1,173 @@
+-- =============================================================================
+-- RLS Anonymous Lockdown Migration — DRAFT (DO NOT APPLY DIRECTLY)
+-- =============================================================================
+-- Generated: 2026-07-03
+-- Branch:    fix/rls-anon-lockdown
+--
+-- Purpose:
+--   Remove the wide-open "Allow public ..." RLS policies (qual/with_check = true)
+--   that let the anon publishable key read/update/delete/insert every row in
+--   `documents` and `signatures`, plus the over-broad "System functions can
+--   manage usage data" policy on `monthly_usage`. After this migration the only
+--   remaining access is owner-scoped (auth.uid() = user_id) for authenticated
+--   users; the anonymous signing flow runs exclusively through the service-role
+--   client in the server actions.
+--
+-- *** APPLY ORDER — READ BEFORE RUNNING ***
+--   Apply the CODE on branch fix/rls-anon-lockdown to production FIRST, then run
+--   this migration. The anonymous signer actions
+--   (saveSignature / markDocumentCompleted / getDocumentFileSignedUrl /
+--    generateSignedPdf / generateSignedPdfFromPdf / createSignedDocumentUploadUrl /
+--    checkAndCompletePublication) were switched to the service-role client on
+--   that branch. If you drop the public policies BEFORE the code is deployed, the
+--   still-anon signer paths lose their documents/signatures access and every
+--   in-progress signing flow breaks.
+--
+-- *** AFTER APPLYING ***
+--   1. Run the unauthenticated (logged-out) signing flow end-to-end:
+--      open a published short URL, sign every area, submit, and confirm the
+--      document reaches `completed` and the signed download works — including a
+--      password-protected publication.
+--   2. Re-run the Supabase security advisor (mcp get_advisors / dashboard) and
+--      confirm the "anon can access documents/signatures" findings are gone.
+--   3. Confirm authenticated owner flows still work: dashboard list, upload,
+--      publish, delete, template publish, usage widget.
+--
+-- NOTE: This file performs DDL. It has NOT been executed against any database.
+--       Test on a Supabase branch / staging project before production.
+--
+-- The whole migration runs in a single transaction: signatures policies are
+-- rebuilt as DROP + CREATE, and a mid-run failure without a transaction would
+-- leave signatures with no policies at all — under RLS that blocks every owner
+-- flow (signature area create/read/delete) until manually repaired.
+-- =============================================================================
+
+BEGIN;
+
+
+-- =============================================================================
+-- (a) documents — drop the public (anon) policies. Keep the owner policies
+--     ("Users can read/insert/update/delete their own documents").
+-- =============================================================================
+DROP POLICY IF EXISTS "Allow public read access" ON public.documents;
+DROP POLICY IF EXISTS "Allow public update"      ON public.documents;
+DROP POLICY IF EXISTS "Allow public delete"      ON public.documents;
+DROP POLICY IF EXISTS "Allow public insert"      ON public.documents;
+
+
+-- =============================================================================
+-- (b) signatures — drop the public (anon) policies and add owner-scoped
+--     policies. `signatures` has no user_id column, so ownership is derived from
+--     the parent document. auth.uid() is wrapped in (select ...) so Postgres
+--     evaluates it once per query (initplan) instead of once per row.
+-- =============================================================================
+DROP POLICY IF EXISTS "Allow public read access" ON public.signatures;
+DROP POLICY IF EXISTS "Allow public update"      ON public.signatures;
+DROP POLICY IF EXISTS "Allow public insert"      ON public.signatures;
+
+CREATE POLICY "Users can read their own signatures" ON public.signatures
+  AS PERMISSIVE FOR SELECT
+  TO authenticated
+  USING (
+    exists (
+      select 1 from public.documents d
+      where d.id = signatures.document_id
+        and d.user_id = (select auth.uid())
+    )
+  );
+
+CREATE POLICY "Users can insert their own signatures" ON public.signatures
+  AS PERMISSIVE FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    exists (
+      select 1 from public.documents d
+      where d.id = signatures.document_id
+        and d.user_id = (select auth.uid())
+    )
+  );
+
+CREATE POLICY "Users can update their own signatures" ON public.signatures
+  AS PERMISSIVE FOR UPDATE
+  TO authenticated
+  USING (
+    exists (
+      select 1 from public.documents d
+      where d.id = signatures.document_id
+        and d.user_id = (select auth.uid())
+    )
+  )
+  WITH CHECK (
+    exists (
+      select 1 from public.documents d
+      where d.id = signatures.document_id
+        and d.user_id = (select auth.uid())
+    )
+  );
+
+CREATE POLICY "Users can delete their own signatures" ON public.signatures
+  AS PERMISSIVE FOR DELETE
+  TO authenticated
+  USING (
+    exists (
+      select 1 from public.documents d
+      where d.id = signatures.document_id
+        and d.user_id = (select auth.uid())
+    )
+  );
+
+
+-- =============================================================================
+-- (c) monthly_usage — drop the over-broad "System functions can manage usage
+--     data" policy (authenticated, FOR ALL, qual=true, with_check=true) that let
+--     any logged-in user read/modify any other user's usage rows.
+--
+--     Owner access remains covered by:
+--       - "Users can view their own usage"   (SELECT, auth.uid() = user_id)
+--       - "Users can update their own usage"  (ALL,    auth.uid() = user_id)
+--         → FOR ALL covers the direct INSERT/SELECT/UPDATE done by
+--           subscription-actions (increment/decrementPublishedCompleted,
+--           getCurrentMonthUsage, getUsageWidgetData); with_check falls back to
+--           the USING qual for INSERT.
+--     Service-role paths (paddle webhook, account deletion, the document status
+--     trigger via service-role writes) bypass RLS entirely.
+-- =============================================================================
+DROP POLICY IF EXISTS "System functions can manage usage data" ON public.monthly_usage;
+
+COMMIT;
+
+
+-- =============================================================================
+-- VERIFICATION QUERIES (run manually AFTER applying — SELECT only)
+-- =============================================================================
+-- 1. There should be NO remaining public/anon "Allow public ..." policies and
+--    no permissive qual/with_check = 'true' policy on these tables:
+--
+--   select tablename, policyname, roles, cmd, qual, with_check
+--   from pg_policies
+--   where schemaname = 'public'
+--     and tablename in ('documents','signatures','monthly_usage')
+--     and (qual = 'true' or with_check = 'true' or roles @> '{public}')
+--   order by tablename, cmd, policyname;
+--   -- expected: 0 rows
+--
+-- 2. signatures should now have exactly the 4 owner policies below:
+--
+--   select policyname, cmd, roles
+--   from pg_policies
+--   where schemaname = 'public' and tablename = 'signatures'
+--   order by cmd, policyname;
+--   -- expected:
+--   --   "Users can delete their own signatures" | DELETE | {authenticated}
+--   --   "Users can insert their own signatures" | INSERT | {authenticated}
+--   --   "Users can read their own signatures"   | SELECT | {authenticated}
+--   --   "Users can update their own signatures" | UPDATE | {authenticated}
+--
+-- 3. Full policy dump for the three tables (sanity check):
+--
+--   select tablename, policyname, permissive, roles, cmd, qual, with_check
+--   from pg_policies
+--   where schemaname = 'public'
+--     and tablename in ('documents','signatures','monthly_usage')
+--   order by tablename, cmd, policyname;
+-- =============================================================================


### PR DESCRIPTION
## 요약

**심각도 높은 보안 이슈 대응**: `documents`/`signatures` 테이블에 `qual=true` 공개 정책이 있어 **anon 키만으로 모든 문서·서명 데이터를 조회/수정/삭제**할 수 있는 상태였습니다. 익명 서명 플로우가 이 공개 정책에 의존하고 있어, 서명자 액션을 service role + 명시적 권한 검증으로 전환한 뒤 공개 정책을 제거하는 2단계 구조로 수정합니다.

## 변경 내용

### 코드 (이 PR로 배포)
- **`getSignableDocument()` 검증 게이트 신설**: 서명자 액션 진입 시 문서→발행(publication) 체인을 service role로 조회해 `status='active'` && 미만료일 때만 통과. 클라이언트가 준 documentId를 더 이상 무검증으로 신뢰하지 않음
- **서명자 액션 6개 service role 전환**: `saveSignature`(+ 완료 문서 서명 거부 추가), `markDocumentCompleted`(멱등성 유지), `getDocumentFileSignedUrl`, `generateSignedPdf`, `generateSignedPdfFromPdf`, `createSignedDocumentUploadUrl`
- `checkAndCompletePublication` service role 전환
- 소유자용 액션은 변경 없음 (기존 `auth.uid()` 정책이 커버)

### DB 마이그레이션 (`db/rls-anon-lockdown-migration.sql`, **미적용 초안**)
- documents: "Allow public read/update/delete/insert" 4개 정책 DROP
- signatures: 공개 정책 3개 DROP + **소유자 정책 4개 신설** (문서 소유 기반, initplan 최적화 형태)
- monthly_usage: "System functions can manage usage data"(qual=true) DROP — 로그인 유저의 타인 사용량 조작 차단
- 전체를 단일 트랜잭션으로 래핑 (중간 실패 시 정책 공백 방지)

## ⚠️ 적용 순서 (중요)

1. **이 PR 머지 → 배포 완료 확인**
2. **그 다음에** `db/rls-anon-lockdown-migration.sql`을 스테이징(Supabase 브랜치) 테스트 후 프로덕션 적용
3. 역순으로 하면 배포 전 서명 플로우가 중단됨 (파일 상단에 명시)

적용 후 확인: 비로그인 서명 E2E(발행 링크 → 서명 → 완료 → 다운로드), 대시보드/업로드/발행 등 소유자 플로우, security advisor 재실행

## 검증

- `tsc --noEmit`: 변경 파일 에러 0건
- `pnpm build` 성공
- documents/signatures/monthly_usage의 모든 코드 접근 경로(서명자/소유자/webhook/트리거)를 전수 매핑해 마이그레이션 후에도 커버되지 않는 경로 없음을 확인
- 부수 효과: 익명 서명자의 문서 완료 시 사용량 트리거가 RLS에 막혀 조용히 실패하던 문제가 service role 실행으로 해소됨

## 참고

- UUID 비추측성 + 발행 링크 경유 노출 구조라, 공개 SELECT 제거만으로 documentId 열거 공격이 차단됩니다
- 만료된 발행에 대한 서명/완료가 이제 명시적으로 거부됩니다 (기존엔 미검증) — 의도된 강화입니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)