### PR TITLE
feat(og): 서명 링크 미리보기에 발행 문서 이름 노출 및 브랜드 OG 이미지 추가

### DIFF
--- a/app/(sign)/sign/[id]/page.tsx
+++ b/app/(sign)/sign/[id]/page.tsx
@@ -1,10 +1,72 @@
+import type { Metadata } from "next";
 import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
 import { getPublicationByShortUrl } from "@/app/actions/publication-actions";
+import { createServiceSupabase } from "@/lib/supabase/server";
 import SignPageContainer from "./components/SignPageContainer";
 
 // Server Component that fetches data and renders SPA container
 interface PageProps {
   params: { id: string };
+}
+
+// Dynamic metadata so shared links (KakaoTalk, iMessage, etc.) preview the
+// publication name. Sign links are private, so keep them out of search indexes.
+// Crawlers send no cookies, so they get the Korean default; human visitors get
+// their saved language, same as the root layout.
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const supabase = createServiceSupabase();
+  const { data: publication } = await supabase
+    .from("publications")
+    .select("name")
+    .eq("short_url", params.id)
+    .eq("is_deleted", false)
+    .single();
+
+  const robots = { index: false, follow: false };
+
+  if (!publication?.name) {
+    return { robots };
+  }
+
+  const cookieStore = cookies();
+  const language =
+    (cookieStore.get("seukSeukLanguage")?.value as "ko" | "en") || "ko";
+
+  const meta = {
+    ko: {
+      description: `"${publication.name}" 문서에 서명이 요청되었습니다. 슥슥에서 확인하고 서명해 주세요.`,
+      siteName: "슥슥",
+      locale: "ko_KR",
+    },
+    en: {
+      description: `You've been requested to sign "${publication.name}". Review and sign it on SeukSeuk.`,
+      siteName: "SeukSeuk",
+      locale: "en_US",
+    },
+  }[language];
+
+  const title = publication.name;
+
+  return {
+    title,
+    description: meta.description,
+    robots,
+    openGraph: {
+      title,
+      description: meta.description,
+      type: "website",
+      siteName: meta.siteName,
+      locale: meta.locale,
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: meta.description,
+    },
+  };
 }
 
 export default async function SignPage({ params }: PageProps) {

--- a/app/(sign)/sign/[id]/page.tsx
+++ b/app/(sign)/sign/[id]/page.tsx
@@ -33,8 +33,10 @@ export async function generateMetadata({
   }
 
   const cookieStore = cookies();
-  const language =
-    (cookieStore.get("seukSeukLanguage")?.value as "ko" | "en") || "ko";
+  // Normalize at runtime: the cookie is user-controlled, and an unexpected
+  // value would make the meta lookup below return undefined.
+  const language: "ko" | "en" =
+    cookieStore.get("seukSeukLanguage")?.value === "en" ? "en" : "ko";
 
   const documents = (publication.documents ?? [])
     .filter((doc) => !doc.is_deleted)

--- a/app/(sign)/sign/[id]/page.tsx
+++ b/app/(sign)/sign/[id]/page.tsx
@@ -14,20 +14,21 @@ interface PageProps {
 // publication name. Sign links are private, so keep them out of search indexes.
 // Crawlers send no cookies, so they get the Korean default; human visitors get
 // their saved language, same as the root layout.
+// Title fallback chain: publication name → first document alias → filename.
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const supabase = createServiceSupabase();
   const { data: publication } = await supabase
     .from("publications")
-    .select("name")
+    .select("name, documents(alias, filename, is_deleted, created_at)")
     .eq("short_url", params.id)
     .eq("is_deleted", false)
     .single();
 
   const robots = { index: false, follow: false };
 
-  if (!publication?.name) {
+  if (!publication) {
     return { robots };
   }
 
@@ -35,20 +36,38 @@ export async function generateMetadata({
   const language =
     (cookieStore.get("seukSeukLanguage")?.value as "ko" | "en") || "ko";
 
+  const documents = (publication.documents ?? [])
+    .filter((doc) => !doc.is_deleted)
+    .sort((a, b) => (a.created_at < b.created_at ? -1 : 1));
+
+  const firstDocLabel =
+    documents[0]?.alias?.trim() || documents[0]?.filename?.trim() || "";
+
+  let title = publication.name?.trim() || "";
+  if (!title && firstDocLabel) {
+    title =
+      documents.length > 1
+        ? language === "ko"
+          ? `${firstDocLabel} 외 ${documents.length - 1}건`
+          : `${firstDocLabel} and ${documents.length - 1} more`
+        : firstDocLabel;
+  }
+  if (!title) {
+    title = language === "ko" ? "서명 요청" : "Signature Request";
+  }
+
   const meta = {
     ko: {
-      description: `"${publication.name}" 문서에 서명이 요청되었습니다. 슥슥에서 확인하고 서명해 주세요.`,
+      description: `"${title}" 문서에 서명이 요청되었습니다. 슥슥에서 확인하고 서명해 주세요.`,
       siteName: "슥슥",
       locale: "ko_KR",
     },
     en: {
-      description: `You've been requested to sign "${publication.name}". Review and sign it on SeukSeuk.`,
+      description: `You've been requested to sign "${title}". Review and sign it on SeukSeuk.`,
       siteName: "SeukSeuk",
       locale: "en_US",
     },
   }[language];
-
-  const title = publication.name;
 
   return {
     title,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,8 +18,10 @@ const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://seukseuk.com";
 // Dynamic metadata based on language
 export async function generateMetadata(): Promise<Metadata> {
   const cookieStore = await cookies();
-  const language =
-    (cookieStore.get("seukSeukLanguage")?.value as "ko" | "en") || "ko";
+  // Normalize at runtime: the cookie is user-controlled, and an unexpected
+  // value would make the meta lookup below return undefined.
+  const language: "ko" | "en" =
+    cookieStore.get("seukSeukLanguage")?.value === "en" ? "en" : "ko";
 
   const meta = {
     ko: {
@@ -93,8 +95,8 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const cookieStore = await cookies();
-  const language =
-    (cookieStore.get("seukSeukLanguage")?.value as "ko" | "en") || "ko";
+  const language: "ko" | "en" =
+    cookieStore.get("seukSeukLanguage")?.value === "en" ? "en" : "ko";
 
   return (
     <html lang={language === "ko" ? "ko" : "en"} suppressHydrationWarning>

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,113 @@
+import { ImageResponse } from "next/og";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "슥슥 SeukSeuk - 온라인 문서 서명 · Online Document Signing";
+
+const BRAND_KO = "슥슥";
+const BRAND_EN = "SeukSeuk";
+const TAGLINE = "온라인 문서 서명 · Online Document Signing";
+const DESCRIPTION = "링크 하나로 서명까지 · Collect signatures with a single link";
+const DOMAIN = "seuk-seuk.com";
+
+// Fetch a Korean font subset containing only the glyphs we render.
+// Google Fonts' css2 endpoint returns a TTF subset when the `text` param is used.
+async function loadKoreanFont(text: string, weight: 400 | 700) {
+  const url = `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@${weight}&text=${encodeURIComponent(
+    text
+  )}`;
+  const css = await (await fetch(url)).text();
+  const resource = css.match(
+    /src: url\((.+?)\) format\('(opentype|truetype)'\)/
+  );
+  if (!resource) {
+    throw new Error("Failed to resolve font resource");
+  }
+  const res = await fetch(resource[1]);
+  if (!res.ok) {
+    throw new Error("Failed to download font");
+  }
+  return res.arrayBuffer();
+}
+
+export default async function Image() {
+  const glyphs = `${BRAND_KO}${BRAND_EN}${TAGLINE}${DESCRIPTION}${DOMAIN}`;
+  const [regular, bold] = await Promise.all([
+    loadKoreanFont(glyphs, 400),
+    loadKoreanFont(glyphs, 700),
+  ]);
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 28,
+          backgroundColor: "#ffffff",
+          backgroundImage:
+            "linear-gradient(135deg, #ffffff 0%, #eff6ff 55%, #dbeafe 100%)",
+          fontFamily: "Noto Sans KR",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 28 }}>
+          <svg
+            width={120}
+            height={120}
+            viewBox="-3 -3 30 30"
+            fill="none"
+            stroke="#2563EB"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m18 5-2.414-2.414A2 2 0 0 0 14.172 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2" />
+            <path d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z" />
+            <path d="M8 18h1" />
+          </svg>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "baseline",
+              gap: 24,
+            }}
+          >
+            <div style={{ fontSize: 110, fontWeight: 700, color: "#1e3a8a" }}>
+              {BRAND_KO}
+            </div>
+            <div style={{ fontSize: 56, fontWeight: 700, color: "#2563eb" }}>
+              {BRAND_EN}
+            </div>
+          </div>
+        </div>
+        <div style={{ fontSize: 40, fontWeight: 700, color: "#0f172a" }}>
+          {TAGLINE}
+        </div>
+        <div style={{ fontSize: 30, fontWeight: 400, color: "#64748b" }}>
+          {DESCRIPTION}
+        </div>
+        <div
+          style={{
+            position: "absolute",
+            bottom: 48,
+            fontSize: 26,
+            color: "#94a3b8",
+          }}
+        >
+          {DOMAIN}
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        { name: "Noto Sans KR", data: regular, weight: 400, style: "normal" },
+        { name: "Noto Sans KR", data: bold, weight: 700, style: "normal" },
+      ],
+    }
+  );
+}

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -7,8 +7,12 @@ export const alt = "슥슥 SeukSeuk - 온라인 문서 서명 · Online Document
 const BRAND_KO = "슥슥";
 const BRAND_EN = "SeukSeuk";
 const TAGLINE = "온라인 문서 서명 · Online Document Signing";
+const TAGLINE_EN = "Online Document Signing";
 const DESCRIPTION = "링크 하나로 서명까지 · Collect signatures with a single link";
+const DESCRIPTION_EN = "Collect signatures with a single link";
 const DOMAIN = "seuk-seuk.com";
+
+const FONT_FETCH_TIMEOUT_MS = 5_000;
 
 // Fetch a Korean font subset containing only the glyphs we render.
 // Google Fonts' css2 endpoint returns a TTF subset when the `text` param is used.
@@ -16,98 +20,140 @@ async function loadKoreanFont(text: string, weight: 400 | 700) {
   const url = `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@${weight}&text=${encodeURIComponent(
     text
   )}`;
-  const css = await (await fetch(url)).text();
+  const css = await (
+    await fetch(url, { signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS) })
+  ).text();
   const resource = css.match(
     /src: url\((.+?)\) format\('(opentype|truetype)'\)/
   );
   if (!resource) {
     throw new Error("Failed to resolve font resource");
   }
-  const res = await fetch(resource[1]);
+  const res = await fetch(resource[1], {
+    signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new Error("Failed to download font");
   }
   return res.arrayBuffer();
 }
 
-export default async function Image() {
-  const glyphs = `${BRAND_KO}${BRAND_EN}${TAGLINE}${DESCRIPTION}${DOMAIN}`;
-  const [regular, bold] = await Promise.all([
-    loadKoreanFont(glyphs, 400),
-    loadKoreanFont(glyphs, 700),
-  ]);
-
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          width: "100%",
-          height: "100%",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: 28,
-          backgroundColor: "#ffffff",
-          backgroundImage:
-            "linear-gradient(135deg, #ffffff 0%, #eff6ff 55%, #dbeafe 100%)",
-          fontFamily: "Noto Sans KR",
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", gap: 28 }}>
-          <svg
-            width={120}
-            height={120}
-            viewBox="-3 -3 30 30"
-            fill="none"
-            stroke="#2563EB"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="m18 5-2.414-2.414A2 2 0 0 0 14.172 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2" />
-            <path d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z" />
-            <path d="M8 18h1" />
-          </svg>
+function BrandImage({
+  brandKo,
+  tagline,
+  description,
+}: {
+  brandKo: string | null;
+  tagline: string;
+  description: string;
+}) {
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 28,
+        backgroundColor: "#ffffff",
+        backgroundImage:
+          "linear-gradient(135deg, #ffffff 0%, #eff6ff 55%, #dbeafe 100%)",
+        fontFamily: "Noto Sans KR",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 28 }}>
+        <svg
+          width={120}
+          height={120}
+          viewBox="-3 -3 30 30"
+          fill="none"
+          stroke="#2563EB"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m18 5-2.414-2.414A2 2 0 0 0 14.172 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2" />
+          <path d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z" />
+          <path d="M8 18h1" />
+        </svg>
+        <div style={{ display: "flex", alignItems: "baseline", gap: 24 }}>
+          {brandKo && (
+            <div style={{ fontSize: 110, fontWeight: 700, color: "#1e3a8a" }}>
+              {brandKo}
+            </div>
+          )}
           <div
             style={{
-              display: "flex",
-              alignItems: "baseline",
-              gap: 24,
+              fontSize: brandKo ? 56 : 96,
+              fontWeight: 700,
+              color: brandKo ? "#2563eb" : "#1e3a8a",
             }}
           >
-            <div style={{ fontSize: 110, fontWeight: 700, color: "#1e3a8a" }}>
-              {BRAND_KO}
-            </div>
-            <div style={{ fontSize: 56, fontWeight: 700, color: "#2563eb" }}>
-              {BRAND_EN}
-            </div>
+            {BRAND_EN}
           </div>
         </div>
-        <div style={{ fontSize: 40, fontWeight: 700, color: "#0f172a" }}>
-          {TAGLINE}
-        </div>
-        <div style={{ fontSize: 30, fontWeight: 400, color: "#64748b" }}>
-          {DESCRIPTION}
-        </div>
-        <div
-          style={{
-            position: "absolute",
-            bottom: 48,
-            fontSize: 26,
-            color: "#94a3b8",
-          }}
-        >
-          {DOMAIN}
-        </div>
       </div>
-    ),
-    {
-      ...size,
-      fonts: [
-        { name: "Noto Sans KR", data: regular, weight: 400, style: "normal" },
-        { name: "Noto Sans KR", data: bold, weight: 700, style: "normal" },
-      ],
-    }
+      <div style={{ fontSize: 40, fontWeight: 700, color: "#0f172a" }}>
+        {tagline}
+      </div>
+      <div style={{ fontSize: 30, fontWeight: 400, color: "#64748b" }}>
+        {description}
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          bottom: 48,
+          fontSize: 26,
+          color: "#94a3b8",
+        }}
+      >
+        {DOMAIN}
+      </div>
+    </div>
   );
+}
+
+export default async function Image() {
+  const glyphs = `${BRAND_KO}${BRAND_EN}${TAGLINE}${DESCRIPTION}${DOMAIN}`;
+
+  try {
+    const [regular, bold] = await Promise.all([
+      loadKoreanFont(glyphs, 400),
+      loadKoreanFont(glyphs, 700),
+    ]);
+
+    return new ImageResponse(
+      (
+        <BrandImage
+          brandKo={BRAND_KO}
+          tagline={TAGLINE}
+          description={DESCRIPTION}
+        />
+      ),
+      {
+        ...size,
+        fonts: [
+          { name: "Noto Sans KR", data: regular, weight: 400, style: "normal" },
+          { name: "Noto Sans KR", data: bold, weight: 700, style: "normal" },
+        ],
+      }
+    );
+  } catch (error) {
+    // Korean font unavailable (Google Fonts slow/down): fall back to a
+    // Latin-only image rendered with the built-in default font instead of
+    // failing the OG image entirely or rendering broken Korean glyphs.
+    console.error("OG image Korean font load failed:", error);
+    return new ImageResponse(
+      (
+        <BrandImage
+          brandKo={null}
+          tagline={TAGLINE_EN}
+          description={DESCRIPTION_EN}
+        />
+      ),
+      size
+    );
+  }
 }


### PR DESCRIPTION
## 개요

카카오톡 등 메신저에서 서명 링크 공유 시 미리보기에 발행 문서 이름이 노출되도록 하고, 현재 아예 없던 OG 이미지(고정 브랜드 이미지)를 추가합니다.

## 변경 사항

### 1. 서명 페이지 동적 메타데이터 (`app/(sign)/sign/[id]/page.tsx`)
- `generateMetadata` 추가: short URL로 발행 이름만 가볍게 조회(service role)해서 `og:title`을 발행 이름으로 설정
- 설명 문구·siteName·locale은 `seukSeukLanguage` 쿠키 기반 ko/en 분기 (크롤러는 쿠키가 없어 한국어 기본값)
- 서명 링크는 사적인 링크이므로 `robots: noindex` 처리 (메신저 미리보기에는 영향 없음)

### 2. 고정 브랜드 OG 이미지 (`app/opengraph-image.tsx`, 신규)
- `ImageResponse` 기반 1200x630 이미지: 슥슥 로고 + "슥슥 SeukSeuk" 워드마크 + 한/영 병기 태그라인
- 글로벌 서비스 고려로 이미지 내 문구는 한/영 병기 (이미지는 언어 분기가 불가능하므로 단일 병기 디자인)
- 한글 폰트는 Google Fonts css2의 `text` 파라미터로 필요한 글자만 서브셋 로드(~7KB), 텍스트가 고정이라 fetch 캐시 적용

## 확인 방법

- `/sign/<shortUrl>` 페이지 소스에서 `og:title`이 발행 이름인지 확인
- `/opengraph-image` 접속 시 브랜드 이미지 렌더링 확인
- 배포 후 기존 공유 링크는 [카카오 공유 디버거](https://developers.kakao.com/tool/debugger/sharing)에서 캐시 초기화 필요

## 참고

- 비밀번호 보호 발행도 미리보기에 이름은 노출됩니다 (공유 목적의 이름이므로 의도된 동작)
- `tsc` 기준 변경 파일 오류 없음. 로컬 `npm run build` 실패는 `RESEND_API_KEY` 부재로 인한 기존 이슈로 본 변경과 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 공유 미리보기용 Open Graph(OG) 이미지가 추가되어 링크 카드의 시각적 품질이 개선되었습니다.
  * 동적 메타데이터가 적용되어 페이지 제목/설명이 언어 설정(한국어/영어)에 맞게 표시됩니다.
* **Improvements**
  * 공유 페이지는 검색 및 크롤링 노출이 차단되도록 메타 정보가 고정 적용됩니다.
  * 메타데이터 언어 판별 기준이 더 일관되게 동작하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->