### PR TITLE
fix(middleware): OG 이미지 등 메타데이터 라우트 인증 리다이렉트 제외

### DIFF
--- a/lib/constants/routes.ts
+++ b/lib/constants/routes.ts
@@ -22,6 +22,13 @@ export const publicRoutes: Routes = {
   "/privacy": true,
   "/term": true,
   "/contact": true,
+  // Metadata file convention routes: crawlers fetch these without auth,
+  // and the middleware matcher only excludes extension-based static assets
+  "/opengraph-image": true,
+  "/twitter-image": true,
+  "/icon": true,
+  "/apple-icon": true,
+  "/manifest.webmanifest": true,
 };
 
 /**


### PR DESCRIPTION
## 문제

PR #176 배포 후 카카오톡 공유 시 제목은 정상 노출되지만 OG 이미지가 뜨지 않음.

Facebook 공유 디버거 확인 결과, `og:image` 태그와 `og:image:width/height`는 정상 출력되고 있으나 **이미지 URL 자체가 크롤러에게 응답되지 않는 상태**:

```
GET /opengraph-image?8f6277017ac2c29d → 307 → /login
GET /manifest.webmanifest            → 307 → /login  (기존 버그)
```

인증 미들웨어 matcher가 확장자 기반 정적 파일만 제외하는데, Next.js 메타데이터 파일 컨벤션 경로는 확장자가 없어 보호 라우트로 취급되어 비로그인 요청(크롤러)이 전부 로그인 페이지로 리다이렉트됨.

## 수정

`lib/constants/routes.ts`의 `publicRoutes`에 메타데이터 파일 컨벤션 경로 등록:
- `/opengraph-image`, `/twitter-image`, `/icon`, `/apple-icon`
- `/manifest.webmanifest` (동일 원인의 기존 버그 함께 수정)

## 검증

- 배포 전: `curl -I https://www.seuk-seuk.com/opengraph-image` → 307 (재현 확인)
- 배포 후: 같은 요청이 200 + `image/png` 응답인지 확인 필요
- 이후 [카카오 공유 디버거](https://developers.kakao.com/tool/debugger/sharing)에서 캐시 초기화 후 미리보기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 메타데이터 관련 경로가 공개 접근 목록에 추가되어, 오픈그래프 이미지, 트위터 이미지, 아이콘, 매니페스트 파일을 인증 없이 더 안정적으로 불러올 수 있게 되었습니다.
  * 공개 라우트 판별이 경로 목록 기준으로 동작하도록 정리되어, 해당 자원 접근이 더 일관되게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->