### PR TITLE
fix(og): 서명 페이지 og:image 누락 수정

### DIFF
--- a/app/(sign)/sign/[id]/page.tsx
+++ b/app/(sign)/sign/[id]/page.tsx
@@ -71,6 +71,16 @@ export async function generateMetadata({
     },
   }[language];
 
+  // Defining `openGraph` here replaces the one inherited from the root layout
+  // wholesale, dropping the file-based /opengraph-image — so re-add it
+  // explicitly (metadataBase in the root layout resolves it to an absolute URL).
+  const ogImage = {
+    url: "/opengraph-image",
+    width: 1200,
+    height: 630,
+    alt: "슥슥 SeukSeuk - 온라인 문서 서명 · Online Document Signing",
+  };
+
   return {
     title,
     description: meta.description,
@@ -81,11 +91,13 @@ export async function generateMetadata({
       type: "website",
       siteName: meta.siteName,
       locale: meta.locale,
+      images: [ogImage],
     },
     twitter: {
       card: "summary_large_image",
       title,
       description: meta.description,
+      images: [ogImage],
     },
   };
 }


### PR DESCRIPTION
## 문제

PR #177로 `/opengraph-image` 엔드포인트는 정상화(200, image/png)됐지만, 서명 페이지(`/sign/[shortUrl]`)에는 여전히 카톡 공유 시 이미지가 뜨지 않음.

실제 페이지 HTML 확인 결과 **`og:image` 메타 태그 자체가 출력되지 않음**:

- 홈페이지: `og:image` + width/height 정상 출력
- 서명 페이지: `og:title`/`og:description`만 있고 `og:image` 없음

## 원인

Next.js 메타데이터 병합은 최상위 키 단위 교체(shallow merge)라서, 서명 페이지 `generateMetadata`가 자체 `openGraph` 객체를 정의하면 루트 레이아웃에서 상속되던 `openGraph` — 파일 컨벤션(`app/opengraph-image.tsx`)이 주입한 `images` 포함 — 가 통째로 사라짐.

## 수정

서명 페이지 `openGraph.images`와 `twitter.images`에 `/opengraph-image`(1200x630)를 명시적으로 재지정. 루트 레이아웃의 `metadataBase`가 절대 URL로 변환.

## 배포 후 확인

```
curl -s https://www.seuk-seuk.com/sign/<shortUrl> | grep og:image
```
→ `og:image`, `og:image:width/height` 태그 출력 확인 후, [카카오 공유 디버거](https://developers.kakao.com/tool/debugger/sharing)에서 해당 링크 캐시 초기화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)