### PR TITLE
feat(og): OG 이미지를 아이콘 중심 심플 디자인으로 교체

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -2,158 +2,54 @@ import { ImageResponse } from "next/og";
 
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
-export const alt = "슥슥 SeukSeuk - 온라인 문서 서명 · Online Document Signing";
+export const alt = "슥슥 SeukSeuk";
 
-const BRAND_KO = "슥슥";
-const BRAND_EN = "SeukSeuk";
-const TAGLINE = "온라인 문서 서명 · Online Document Signing";
-const TAGLINE_EN = "Online Document Signing";
-const DESCRIPTION = "링크 하나로 서명까지 · Collect signatures with a single link";
-const DESCRIPTION_EN = "Collect signatures with a single link";
-const DOMAIN = "seuk-seuk.com";
-
-const FONT_FETCH_TIMEOUT_MS = 5_000;
-
-// Fetch a Korean font subset containing only the glyphs we render.
-// Google Fonts' css2 endpoint returns a TTF subset when the `text` param is used.
-async function loadKoreanFont(text: string, weight: 400 | 700) {
-  const url = `https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@${weight}&text=${encodeURIComponent(
-    text
-  )}`;
-  const css = await (
-    await fetch(url, { signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS) })
-  ).text();
-  const resource = css.match(
-    /src: url\((.+?)\) format\('(opentype|truetype)'\)/
-  );
-  if (!resource) {
-    throw new Error("Failed to resolve font resource");
-  }
-  const res = await fetch(resource[1], {
-    signal: AbortSignal.timeout(FONT_FETCH_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    throw new Error("Failed to download font");
-  }
-  return res.arrayBuffer();
-}
-
-function BrandImage({
-  brandKo,
-  tagline,
-  description,
-}: {
-  brandKo: string | null;
-  tagline: string;
-  description: string;
-}) {
-  return (
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 28,
-        backgroundColor: "#ffffff",
-        backgroundImage:
-          "linear-gradient(135deg, #ffffff 0%, #eff6ff 55%, #dbeafe 100%)",
-        fontFamily: "Noto Sans KR",
-      }}
-    >
-      <div style={{ display: "flex", alignItems: "center", gap: 28 }}>
-        <svg
-          width={120}
-          height={120}
-          viewBox="-3 -3 30 30"
-          fill="none"
-          stroke="#2563EB"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="m18 5-2.414-2.414A2 2 0 0 0 14.172 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2" />
-          <path d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z" />
-          <path d="M8 18h1" />
-        </svg>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 24 }}>
-          {brandKo && (
-            <div style={{ fontSize: 110, fontWeight: 700, color: "#1e3a8a" }}>
-              {brandKo}
-            </div>
-          )}
-          <div
-            style={{
-              fontSize: brandKo ? 56 : 96,
-              fontWeight: 700,
-              color: brandKo ? "#2563eb" : "#1e3a8a",
-            }}
-          >
-            {BRAND_EN}
-          </div>
-        </div>
-      </div>
-      <div style={{ fontSize: 40, fontWeight: 700, color: "#0f172a" }}>
-        {tagline}
-      </div>
-      <div style={{ fontSize: 30, fontWeight: 400, color: "#64748b" }}>
-        {description}
-      </div>
+// Icon-only brand image: no text means no Korean font to load,
+// so this renders with zero external dependencies.
+export default function Image() {
+  return new ImageResponse(
+    (
       <div
         style={{
-          position: "absolute",
-          bottom: 48,
-          fontSize: 26,
-          color: "#94a3b8",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundImage:
+            "linear-gradient(135deg, #ffffff 0%, #eff6ff 55%, #dbeafe 100%)",
         }}
       >
-        {DOMAIN}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 380,
+            height: 380,
+            backgroundColor: "#ffffff",
+            borderRadius: 88,
+            border: "1px solid #e2e8f0",
+            boxShadow: "0 24px 64px rgba(37, 99, 235, 0.16)",
+          }}
+        >
+          <svg
+            width={220}
+            height={220}
+            viewBox="-3 -3 30 30"
+            fill="none"
+            stroke="#2563EB"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m18 5-2.414-2.414A2 2 0 0 0 14.172 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2" />
+            <path d="M21.378 12.626a1 1 0 0 0-3.004-3.004l-4.01 4.012a2 2 0 0 0-.506.854l-.837 2.87a.5.5 0 0 0 .62.62l2.87-.837a2 2 0 0 0 .854-.506z" />
+            <path d="M8 18h1" />
+          </svg>
+        </div>
       </div>
-    </div>
+    ),
+    size
   );
-}
-
-export default async function Image() {
-  const glyphs = `${BRAND_KO}${BRAND_EN}${TAGLINE}${DESCRIPTION}${DOMAIN}`;
-
-  try {
-    const [regular, bold] = await Promise.all([
-      loadKoreanFont(glyphs, 400),
-      loadKoreanFont(glyphs, 700),
-    ]);
-
-    return new ImageResponse(
-      (
-        <BrandImage
-          brandKo={BRAND_KO}
-          tagline={TAGLINE}
-          description={DESCRIPTION}
-        />
-      ),
-      {
-        ...size,
-        fonts: [
-          { name: "Noto Sans KR", data: regular, weight: 400, style: "normal" },
-          { name: "Noto Sans KR", data: bold, weight: 700, style: "normal" },
-        ],
-      }
-    );
-  } catch (error) {
-    // Korean font unavailable (Google Fonts slow/down): fall back to a
-    // Latin-only image rendered with the built-in default font instead of
-    // failing the OG image entirely or rendering broken Korean glyphs.
-    console.error("OG image Korean font load failed:", error);
-    return new ImageResponse(
-      (
-        <BrandImage
-          brandKo={null}
-          tagline={TAGLINE_EN}
-          description={DESCRIPTION_EN}
-        />
-      ),
-      size
-    );
-  }
 }


### PR DESCRIPTION
## 변경

기존 OG 이미지는 워드마크 + 한/영 태그라인 + 설명 + 도메인까지 텍스트가 많아 메신저 미리보기(작은 사이즈)에서 지저분하게 보임.

그라데이션 배경 + 흰색 라운드 카드 + 브랜드 아이콘만 남긴 아이콘 중심 디자인으로 교체.

## 부수 효과

텍스트가 없어지면서 Google Fonts 한글 서브셋 로딩 코드(fetch 2회, AbortSignal 타임아웃, 영문 폴백 이미지)가 전부 불필요해져 삭제. 외부 의존성 없이 렌더링되므로 폰트 장애·타임아웃 리스크 자체가 사라짐.

## 확인

Vercel 프리뷰 배포의 `/opengraph-image`에서 디자인 확인 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)