### PR TITLE
fix(og): 서명 페이지 og:image URL에 버전 쿼리 추가

### DIFF
--- a/app/(sign)/sign/[id]/page.tsx
+++ b/app/(sign)/sign/[id]/page.tsx
@@ -74,8 +74,11 @@ export async function generateMetadata({
   // Defining `openGraph` here replaces the one inherited from the root layout
   // wholesale, dropping the file-based /opengraph-image — so re-add it
   // explicitly (metadataBase in the root layout resolves it to an absolute URL).
+  // The `v` query busts messenger-side image caches (Kakao caches images per
+  // URL, independent of the page scrape cache) — bump it when the OG image
+  // design changes.
   const ogImage = {
-    url: "/opengraph-image",
+    url: "/opengraph-image?v=2",
     width: 1200,
     height: 630,
     alt: "슥슥 SeukSeuk - 온라인 문서 서명 · Online Document Signing",


### PR DESCRIPTION
## 문제

PR #179 배포 후에도 카카오 공유 디버거에서 캐시를 초기화해도 서명 링크 미리보기에 이전 텍스트 디자인 이미지가 계속 노출됨.

실서비스 `/opengraph-image`는 새 아이콘 디자인을 정상 응답 중임을 확인. 원인은 카카오가 **이미지를 URL 단위로 별도 캐싱**하기 때문 — 서명 페이지의 og:image URL(`/opengraph-image`)이 변경 전후 동일해서 카카오 이미지 CDN이 구버전을 유지함.

홈페이지는 Next.js 파일 컨벤션이 빌드 해시 쿼리(`?8f6277...`)를 자동으로 붙여 배포마다 URL이 갱신되지만, 서명 페이지는 metadata에 하드코딩한 URL이라 해시가 없음.

## 수정

서명 페이지 og:image URL을 `/opengraph-image?v=2`로 변경. 라우트는 쿼리를 무시하므로 동작 동일, 카카오·Vercel 캐시 키만 갱신됨. **이후 OG 이미지 디자인을 바꿀 때는 `v`를 올려야 함.**

## 검증

- `https://www.seuk-seuk.com/opengraph-image?v=2` → 200, image/png 확인 완료
- 배포 후 카카오 공유 디버거에서 서명 링크 캐시 초기화 → 새 이미지 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Open Graph 이미지가 최신 버전으로 반영되도록 이미지 URL에 버전 쿼리 파라미터를 적용했습니다.
  * 캐시로 인해 오래된 미리보기 이미지가 표시되는 문제를 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->