### PR TITLE
feat(document): 문서 서명 완료일(completed_at) 적재 및 발행 상세화면 노출

### DIFF
--- a/app/actions/document-actions.ts
+++ b/app/actions/document-actions.ts
@@ -395,7 +395,7 @@ export async function markDocumentCompleted(documentId: string) {
     // Update document status to completed
     const { error } = await service
       .from("documents")
-      .update({ status: "completed" })
+      .update({ status: "completed", completed_at: new Date().toISOString() })
       .eq("id", documentId);
 
     if (error) {

--- a/components/publication/publication-detail-content.tsx
+++ b/components/publication/publication-detail-content.tsx
@@ -399,6 +399,19 @@ export function PublicationDetailContent({
                                 }
                               )}
                             </span>
+                            {document.status === "completed" && document.completed_at && (
+                              <span>
+                                {t("publicationDetail.completedAt")}:{" "}
+                                {new Date(document.completed_at).toLocaleDateString(
+                                  language === "ko" ? "ko-KR" : "en-US",
+                                  {
+                                    year: "numeric",
+                                    month: "short",
+                                    day: "numeric",
+                                  }
+                                )}
+                              </span>
+                            )}
                             {totalSignatures > 0 && (
                               <span>
                                 {t("publicationDetail.signatures")}: {completedSignatures}/{totalSignatures}

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -139,6 +139,7 @@ export type Database = {
       documents: {
         Row: {
           alias: string | null
+          completed_at: string | null
           created_at: string
           created_month: string
           deleted_at: string | null
@@ -156,6 +157,7 @@ export type Database = {
         }
         Insert: {
           alias?: string | null
+          completed_at?: string | null
           created_at?: string
           created_month: string
           deleted_at?: string | null
@@ -173,6 +175,7 @@ export type Database = {
         }
         Update: {
           alias?: string | null
+          completed_at?: string | null
           created_at?: string
           created_month?: string
           deleted_at?: string | null

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -566,6 +566,7 @@ export default {
   "publicationDetail.status.expired": "Expired",
   "publicationDetail.status.unknown": "Unknown",
   "publicationDetail.createdAt": "Created",
+  "publicationDetail.completedAt": "Signed",
   "publicationDetail.expiresAt": "Expires",
   "publicationDetail.password": "Password",
   "publicationDetail.passwordSet": "Set",

--- a/locales/ko.ts
+++ b/locales/ko.ts
@@ -561,6 +561,7 @@ export default {
   "publicationDetail.status.expired": "만료됨",
   "publicationDetail.status.unknown": "알 수 없음",
   "publicationDetail.createdAt": "생성일",
+  "publicationDetail.completedAt": "서명 완료일",
   "publicationDetail.expiresAt": "만료일",
   "publicationDetail.password": "비밀번호",
   "publicationDetail.passwordSet": "설정됨",


### PR DESCRIPTION
## 개요
발행 상세화면에서 문서 생성일만 노출되던 것을 개선해, 서명 제출 완료일(계약서라면 계약날짜)을 함께 노출합니다.

## 배경
- 개별 서명 영역의 서명 시각(`signatures.signed_at`)은 100% 적재 중이었으나, 문서 제출 완료 시각은 어디에도 저장되지 않았음
- `markDocumentCompleted`가 `status='completed'`로만 업데이트하고 타임스탬프를 기록하지 않았음

## 변경 사항
### DB (마이그레이션 `add_documents_completed_at` — 적용 완료)
- `documents.completed_at` (timestamptz) 컬럼 추가
- 기존 완료 문서 백필: 문서별 `MAX(signatures.signed_at)`으로 747건 중 746건 채움 (나머지 1건은 서명 기록이 없는 소프트 삭제 문서라 NULL 유지)

### 코드
- `app/actions/document-actions.ts` — 제출 시 `completed_at` 기록 (completed 전환 경로는 이 함수 하나뿐)
- `lib/supabase/database.types.ts` — `documents` 타입에 `completed_at` 추가
- `components/publication/publication-detail-content.tsx` — 문서 카드에 서명 완료일 노출 (완료 상태 + `completed_at` 존재 시)
- `locales/ko.ts` / `locales/en.ts` — `publicationDetail.completedAt` 번역 키 추가

## 검증
- 백필 결과 SQL로 확인 (746/747)
- `tsc --noEmit` — 변경 파일 오류 없음 (paddle webhook 기존 오류만 잔존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 문서가 완료되면 완료 일시가 저장되어, 완료된 문서의 상태 정보를 더 정확하게 확인할 수 있게 되었습니다.
  * 문서 상세 화면에서 완료된 문서에 한해 “완료일”이 표시되며, 사용 중인 언어에 맞게 날짜 형식이 현지화됩니다.

* **버그 수정**
  * 문서 완료 처리 시 상태만 변경되던 부분을 개선해 완료 시각도 함께 남도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->