### PR TITLE
feat(sign): 페이지 단위 일괄서명 기능

### DIFF
--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -478,8 +478,8 @@ export default function SignSingleDocument({
     setIsSaving(true);
     setError(null);
 
+    const signedIndexes: number[] = [];
     try {
-      const signedIndexes: number[] = [];
       for (const target of batchSignTargets) {
         const result = await saveSignature(
           documentData.id,
@@ -492,7 +492,11 @@ export default function SignSingleDocument({
         }
         signedIndexes.push(target.area_index);
       }
-
+    } catch (error) {
+      console.error("Error batch signing:", error);
+      setError("Failed to save signature");
+    } finally {
+      // Reflect areas already persisted server-side even if a later save threw
       if (signedIndexes.length > 0) {
         setLocalSignatures((prev) =>
           prev.map((s) =>
@@ -502,10 +506,6 @@ export default function SignSingleDocument({
           )
         );
       }
-    } catch (error) {
-      console.error("Error batch signing:", error);
-      setError("Failed to save signature");
-    } finally {
       setIsSaving(false);
     }
   };

--- a/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
+++ b/app/(sign)/sign/[id]/components/SignSingleDocument.tsx
@@ -15,6 +15,16 @@ import TextInputModal from "@/components/text-input-modal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AnimatedCircularProgressBar } from "@/components/ui/animated-circular-progress-bar";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useLanguage } from "@/contexts/language-context";
 import type { ClientDocument, Signature, PublicationWithDocuments } from "@/lib/supabase/database.types";
 import {
@@ -33,6 +43,7 @@ import {
   FileSignature,
   PenLine,
   RefreshCw,
+  Stamp,
   Type,
   ZoomIn,
   ZoomOut,
@@ -122,6 +133,9 @@ export default function SignSingleDocument({
   const [touchStartZoom, setTouchStartZoom] = useState<number>(1);
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
   const [documentSignedUrl, setDocumentSignedUrl] = useState<string | null>(null);
+  // Last drawn signature, kept locally so remaining areas can be batch-signed
+  const [lastSignatureData, setLastSignatureData] = useState<string | null>(null);
+  const [isBatchConfirmOpen, setIsBatchConfirmOpen] = useState<boolean>(false);
   const [isLoadingSignedUrl, setIsLoadingSignedUrl] = useState<boolean>(false);
 
   const isPdf = (documentData as any).file_type === 'pdf';
@@ -186,6 +200,10 @@ export default function SignSingleDocument({
           signed_at: null,
         };
         setLocalSignatures([...localSignatures, newSignature]);
+      }
+
+      if (selectedAreaType === "signature") {
+        setLastSignatureData(signatureData);
       }
 
       setIsModalOpen(false);
@@ -441,6 +459,54 @@ export default function SignSingleDocument({
       setIsGenerating(false);
       setGeneratingProgress("");
       setProgressValue(0);
+    }
+  };
+
+  // Unsigned signature-type areas on the current page (text areas excluded)
+  const batchSignTargets = localSignatures.filter(
+    (s) =>
+      s.signature_data === null &&
+      (s as any).area_type !== "text" &&
+      (!isPdf || ((s as any).page_number ?? 0) === currentPdfPage - 1)
+  );
+  const canBatchSign = lastSignatureData !== null && batchSignTargets.length > 0;
+
+  const handleBatchSign = async () => {
+    if (!lastSignatureData || batchSignTargets.length === 0 || isSaving) return;
+
+    setIsBatchConfirmOpen(false);
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      const signedIndexes: number[] = [];
+      for (const target of batchSignTargets) {
+        const result = await saveSignature(
+          documentData.id,
+          target.area_index,
+          lastSignatureData
+        );
+        if (result.error) {
+          setError(resolveActionError(result));
+          break;
+        }
+        signedIndexes.push(target.area_index);
+      }
+
+      if (signedIndexes.length > 0) {
+        setLocalSignatures((prev) =>
+          prev.map((s) =>
+            signedIndexes.includes(s.area_index)
+              ? { ...s, signature_data: lastSignatureData }
+              : s
+          )
+        );
+      }
+    } catch (error) {
+      console.error("Error batch signing:", error);
+      setError("Failed to save signature");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -770,14 +836,26 @@ export default function SignSingleDocument({
               </p>
             )}
           </div>
-          <Button
-            onClick={handleGenerateDocument}
-            disabled={!allAreasSigned || isGenerating}
-            size="lg"
-            className="shrink-0 self-end sm:self-auto"
-          >
-            {t("sign.saveDocument")}
-          </Button>
+          <div className="flex gap-2 shrink-0 self-end sm:self-auto">
+            {lastSignatureData && (
+              <Button
+                variant="outline"
+                onClick={() => setIsBatchConfirmOpen(true)}
+                disabled={!canBatchSign || isSaving}
+                size="lg"
+              >
+                <Stamp className="mr-2 h-4 w-4" />
+                {t("sign.batchSign")}
+              </Button>
+            )}
+            <Button
+              onClick={handleGenerateDocument}
+              disabled={!allAreasSigned || isGenerating}
+              size="lg"
+            >
+              {t("sign.saveDocument")}
+            </Button>
+          </div>
         </div>
 
         {/* PDF Page Navigation */}
@@ -1029,6 +1107,36 @@ export default function SignSingleDocument({
           />
         )
       )}
+
+      {/* Batch sign confirmation */}
+      <AlertDialog open={isBatchConfirmOpen} onOpenChange={setIsBatchConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("sign.batchSign")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("sign.batchSignConfirm").replace(
+                "{{count}}",
+                String(batchSignTargets.length)
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {lastSignatureData && (
+            <div className="flex justify-center rounded-md border bg-muted/30 p-3">
+              <img
+                src={lastSignatureData}
+                alt="Signature preview"
+                className="h-16 object-contain"
+              />
+            </div>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("sign.batchSignCancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={handleBatchSign}>
+              {t("sign.batchSignAction")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Loading indicator for signature saving */}
       {isSaving && (

--- a/locales/en.ts
+++ b/locales/en.ts
@@ -351,6 +351,13 @@ export default {
   "sign.signProgress": "{{completed}}/{{total}} signatures completed",
   "sign.allSignedPrompt": "All signatures are complete. Please submit the document.",
 
+  // Batch sign
+  "sign.batchSign": "Sign all",
+  "sign.batchSignConfirm":
+    "Apply the signature below to the {{count}} remaining signature area(s) on this page. Continue?",
+  "sign.batchSignAction": "Apply to all",
+  "sign.batchSignCancel": "Cancel",
+
   // Password gate trust footer
   "sign.password.trustNote": "Securely delivered with SeukSeuk",
   "sign.password.terms": "Terms of Service",

--- a/locales/ko.ts
+++ b/locales/ko.ts
@@ -348,6 +348,13 @@ export default {
   "sign.signProgress": "{{completed}}/{{total}} 서명 완료",
   "sign.allSignedPrompt": "모든 서명이 완료되었습니다. 문서를 제출해 주세요.",
 
+  // Batch sign
+  "sign.batchSign": "일괄서명",
+  "sign.batchSignConfirm":
+    "이 페이지의 남은 서명 영역 {{count}}곳에 아래 서명을 일괄 적용합니다. 계속할까요?",
+  "sign.batchSignAction": "일괄 적용",
+  "sign.batchSignCancel": "취소",
+
   // Password gate trust footer
   "sign.password.trustNote": "슥슥(SeukSeuk)으로 안전하게 전송됩니다",
   "sign.password.terms": "이용약관",


### PR DESCRIPTION
## 요약
- 서명 페이지에서 첫 서명을 완료하면 해당 서명 데이터를 로컬 상태에 보관
- 현재 페이지에 미서명 **서명 타입** 영역이 있으면 상단에 일괄서명 버튼 활성화 (텍스트 입력 영역 제외)
- 클릭 시 확인 다이얼로그(적용 영역 수 + 서명 미리보기) → 해당 페이지의 남은 영역에 순차 저장
- PDF는 현재 페이지(page_number) 기준으로 범위 제한, 이미지 문서는 전체 영역 대상
- 페이지 이동 후에도 버튼이 유지되어 페이지마다 반복 가능

## 동작
첫 서명 → 일괄서명 버튼 활성화 → (확인 다이얼로그) → 현재 페이지 일괄 적용 → 다음 페이지 이동 → 반복

## 비고
- 중간 저장 실패 시 성공분까지만 반영하고 에러 표시
- 서명 데이터는 컴포넌트 메모리에만 보관 (localStorage 미사용)
- i18n: ko/en 키 4개 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 현재 PDF 페이지의 미서명 서명 영역에 최근 입력한 서명을 한 번에 적용할 수 있습니다.
  * 실행 전 확인 대화상자에서 일괄 서명을 적용하거나 취소할 수 있습니다.
  * 서명 저장에 실패한 영역은 오류로 안내되며, 성공한 영역만 반영됩니다.
  * 관련 기능 안내가 한국어와 영어로 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->